### PR TITLE
add volume indication to trading performance. More volume is more costs

### DIFF
--- a/ninjabot.go
+++ b/ninjabot.go
@@ -130,12 +130,13 @@ func (n *NinjaBot) SubscribeOrder(subscriptions ...OrderSubscriber) {
 
 func (n *NinjaBot) Summary() {
 	var (
-		total float64
-		wins  int
-		loses int
+		total  float64
+		wins   int
+		loses  int
+		volume float64
 	)
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Pair", "Trades", "Win", "Loss", "% Win", "Payoff", "Profit"})
+	table.SetHeader([]string{"Pair", "Trades", "Win", "Loss", "% Win", "Payoff", "Profit", "Volume"})
 	table.SetFooterAlignment(tablewriter.ALIGN_RIGHT)
 	avgPayoff := 0.0
 	for _, summary := range n.orderController.Results {
@@ -147,12 +148,15 @@ func (n *NinjaBot) Summary() {
 			strconv.Itoa(len(summary.Lose)),
 			fmt.Sprintf("%.1f %%", float64(len(summary.Win))/float64(len(summary.Win)+len(summary.Lose))*100),
 			fmt.Sprintf("%.3f", summary.Payoff()),
-			fmt.Sprintf("%.4f", summary.Profit()),
+			fmt.Sprintf("%.2f", summary.Profit()),
+			fmt.Sprintf("%.2f", summary.Volume),
 		})
 		total += summary.Profit()
 		wins += len(summary.Win)
 		loses += len(summary.Lose)
+		volume += summary.Volume
 	}
+
 	table.SetFooter([]string{
 		"TOTAL",
 		strconv.Itoa(wins + loses),
@@ -160,7 +164,8 @@ func (n *NinjaBot) Summary() {
 		strconv.Itoa(loses),
 		fmt.Sprintf("%.1f %%", float64(wins)/float64(wins+loses)*100),
 		fmt.Sprintf("%.3f", avgPayoff/float64(wins+loses)),
-		fmt.Sprintf("%.4f", total),
+		fmt.Sprintf("%.2f", total),
+		fmt.Sprintf("%.2f", volume),
 	})
 	table.Render()
 }

--- a/pkg/exchange/paperwallet.go
+++ b/pkg/exchange/paperwallet.go
@@ -29,6 +29,7 @@ type PaperWallet struct {
 	orders       []model.Order
 	assets       map[string]*assetInfo
 	avgPrice     map[string]float64
+	volume       map[string]float64
 	lastCandle   map[string]model.Candle
 	fistCandle   map[string]model.Candle
 }
@@ -66,6 +67,7 @@ func NewPaperWallet(ctx context.Context, baseCoin string, options ...PaperWallet
 		fistCandle: make(map[string]model.Candle),
 		lastCandle: make(map[string]model.Candle),
 		avgPrice:   make(map[string]float64),
+		volume:     make(map[string]float64),
 	}
 
 	for _, option := range options {
@@ -88,11 +90,13 @@ func (p *PaperWallet) Summary() {
 	var (
 		total        float64
 		marketChange float64
+		volume       float64
 	)
 
 	fmt.Println("--------------")
 	fmt.Println("WALLET SUMMARY")
 	fmt.Println("--------------")
+
 	for pair, price := range p.avgPrice {
 		asset, _ := SplitAssetQuote(pair)
 		quantity := p.assets[asset].Free + p.assets[asset].Lock
@@ -100,6 +104,16 @@ func (p *PaperWallet) Summary() {
 		marketChange += (p.lastCandle[pair].Close - p.fistCandle[pair].Close) / p.fistCandle[pair].Close
 		fmt.Printf("%f %s\n", quantity, asset)
 	}
+
+	fmt.Println()
+	fmt.Println("VOLUMES:")
+	for symbol, vol := range p.volume {
+		volume += vol
+		fmt.Printf("%s        = %.2f %s\n", symbol, vol, p.baseCoin)
+		//fmt.Println("START PORTFOLIO = ", p.initialValue, p.baseCoin)
+	}
+	fmt.Println()
+
 	avgMarketChange := marketChange / float64(len(p.avgPrice))
 	baseCoinValue := p.assets[p.baseCoin].Free + p.assets[p.baseCoin].Lock
 	profit := total + baseCoinValue - p.initialValue
@@ -109,6 +123,8 @@ func (p *PaperWallet) Summary() {
 	fmt.Println("FINAL PORTFOLIO = ", total+baseCoinValue, p.baseCoin)
 	fmt.Printf("GROSS PROFIT    =  %f %s (%.2f%%)\n", profit, p.baseCoin, profit/p.initialValue*100)
 	fmt.Printf("MARKET CHANGE   =  %.2f%%\n", avgMarketChange*100)
+	fmt.Printf("VOLUME          =  %.2f %s\n", volume, p.baseCoin)
+	fmt.Printf("COSTS (0.001*V) =  %.2f %s\n", volume*0.001, p.baseCoin)
 	fmt.Println("--------------")
 }
 
@@ -136,6 +152,10 @@ func (p *PaperWallet) OnCandle(candle model.Candle) {
 			continue
 		}
 
+		if _, ok := p.volume[candle.Symbol]; !ok {
+			p.volume[candle.Symbol] = 0
+		}
+
 		asset, quote := SplitAssetQuote(order.Symbol)
 		if order.Side == model.SideTypeBuy && order.Price <= candle.Close {
 			if _, ok := p.assets[asset]; !ok {
@@ -143,13 +163,14 @@ func (p *PaperWallet) OnCandle(candle model.Candle) {
 			}
 
 			actualQty := p.assets[asset].Free + p.assets[asset].Lock
-			orderValue := order.Price * order.Quantity
+			orderVolume := order.Price * order.Quantity
 			walletValue := p.avgPrice[candle.Symbol] * actualQty
 
+			p.volume[candle.Symbol] += orderVolume
 			p.orders[i].Status = model.OrderStatusTypeFilled
-			p.avgPrice[candle.Symbol] = (walletValue + orderValue) / (actualQty + order.Quantity)
+			p.avgPrice[candle.Symbol] = (walletValue + orderVolume) / (actualQty + order.Quantity)
 			p.assets[asset].Free = p.assets[asset].Free + order.Quantity
-			p.assets[quote].Lock = p.assets[quote].Lock - orderValue
+			p.assets[quote].Lock = p.assets[quote].Lock - orderVolume
 		}
 
 		if order.Side == model.SideTypeSell {
@@ -168,7 +189,7 @@ func (p *PaperWallet) OnCandle(candle model.Candle) {
 				continue
 			}
 
-			// cancel other others from same group
+			// Cancel other orders from same group
 			if order.GroupID != nil {
 				for j, groupOrder := range p.orders {
 					if groupOrder.GroupID != nil && *groupOrder.GroupID == *order.GroupID &&
@@ -183,10 +204,12 @@ func (p *PaperWallet) OnCandle(candle model.Candle) {
 				p.assets[quote] = &assetInfo{}
 			}
 
+			orderVolume := order.Quantity * orderPrice
 			profitValue := order.Quantity*orderPrice - order.Quantity*p.avgPrice[candle.Symbol]
 			percentage := profitValue / (order.Quantity * p.avgPrice[candle.Symbol])
 			log.Infof("PROFIT = %.4f %s (%.2f %%)", profitValue, quote, percentage*100)
 
+			p.volume[candle.Symbol] += orderVolume
 			p.orders[i].UpdatedAt = candle.Time
 			p.orders[i].Status = model.OrderStatusTypeFilled
 			p.assets[asset].Lock = p.assets[asset].Lock - order.Quantity
@@ -323,6 +346,12 @@ func (p *PaperWallet) OrderMarket(side model.SideType, symbol string, size float
 		p.assets[quote].Free = p.assets[quote].Free - (size * p.lastCandle[symbol].Close)
 		p.assets[asset].Free = p.assets[asset].Free + size
 	}
+
+	if _, ok := p.volume[symbol]; !ok {
+		p.volume[symbol] = 0
+	}
+
+	p.volume[symbol] += p.lastCandle[symbol].Close * size
 
 	order := model.Order{
 		ExchangeID: p.ID(),

--- a/pkg/exchange/paperwallet.go
+++ b/pkg/exchange/paperwallet.go
@@ -110,7 +110,6 @@ func (p *PaperWallet) Summary() {
 	for symbol, vol := range p.volume {
 		volume += vol
 		fmt.Printf("%s        = %.2f %s\n", symbol, vol, p.baseCoin)
-		//fmt.Println("START PORTFOLIO = ", p.initialValue, p.baseCoin)
 	}
 	fmt.Println()
 
@@ -124,7 +123,7 @@ func (p *PaperWallet) Summary() {
 	fmt.Printf("GROSS PROFIT    =  %f %s (%.2f%%)\n", profit, p.baseCoin, profit/p.initialValue*100)
 	fmt.Printf("MARKET CHANGE   =  %.2f%%\n", avgMarketChange*100)
 	fmt.Printf("VOLUME          =  %.2f %s\n", volume, p.baseCoin)
-	fmt.Printf("COSTS (0.001*V) =  %.2f %s\n", volume*0.001, p.baseCoin)
+	fmt.Printf("COSTS (0.001*V) =  %.2f %s (ESTIMATION) \n", volume*0.001, p.baseCoin)
 	fmt.Println("--------------")
 }
 

--- a/pkg/exchange/paperwallet.go
+++ b/pkg/exchange/paperwallet.go
@@ -106,7 +106,7 @@ func (p *PaperWallet) Summary() {
 	}
 
 	fmt.Println()
-	fmt.Println("VOLUMES:")
+	fmt.Println("TRADING VOLUME")
 	for symbol, vol := range p.volume {
 		volume += vol
 		fmt.Printf("%s        = %.2f %s\n", symbol, vol, p.baseCoin)

--- a/pkg/order/controller.go
+++ b/pkg/order/controller.go
@@ -126,11 +126,7 @@ func (c *Controller) calculateProfit(o *model.Order) (value, percent, volume flo
 			quantity = math.Max(quantity-order.Quantity, 0)
 		}
 
-		// Fees are often determined by 30day volume.
-		// binance starts 0.001
-		// others at 0.0025
 		// We keep track of volume to have an indication of costs. (0.001%) binance.
-		// TODO do someting with trading fee
 		tradeVolume += order.Quantity * order.Price
 	}
 

--- a/pkg/order/controller_test.go
+++ b/pkg/order/controller_test.go
@@ -33,19 +33,21 @@ func TestController_calculateProfit(t *testing.T) {
 		sellOrder, err := controller.OrderMarket(model.SideTypeSell, "BTCUSDT", 1)
 		require.NoError(t, err)
 
-		value, profit, err := controller.calculateProfit(&sellOrder)
+		value, profit, volume, err := controller.calculateProfit(&sellOrder)
 		require.NoError(t, err)
 		assert.Equal(t, 1500.0, value)
 		assert.Equal(t, 1.0, profit)
+		assert.Equal(t, 3000.0, volume)
 
 		// sell remaining BTC, 50% of loss
 		wallet.OnCandle(model.Candle{Symbol: "BTCUSDT", Close: 750})
 		sellOrder, err = controller.OrderMarket(model.SideTypeSell, "BTCUSDT", 1)
 		require.NoError(t, err)
-		value, profit, err = controller.calculateProfit(&sellOrder)
+		value, profit, volume, err = controller.calculateProfit(&sellOrder)
 		require.NoError(t, err)
 		assert.Equal(t, -750.0, value)
 		assert.Equal(t, -0.5, profit)
+		assert.Equal(t, 6000.0, volume)
 	})
 
 	t.Run("limit order", func(t *testing.T) {
@@ -69,10 +71,11 @@ func TestController_calculateProfit(t *testing.T) {
 		wallet.OnCandle(model.Candle{Time: time.Now(), Symbol: "BTCUSDT", High: 2000, Close: 2000})
 		controller.updateOrders()
 
-		value, profit, err := controller.calculateProfit(&sellOrder)
+		value, profit, volume, err := controller.calculateProfit(&sellOrder)
 		require.NoError(t, err)
 		assert.Equal(t, 1000.0, value)
 		assert.Equal(t, 1.0, profit)
+		assert.Equal(t, 7750.0, volume)
 	})
 
 	t.Run("oco order limit maker", func(t *testing.T) {
@@ -96,10 +99,11 @@ func TestController_calculateProfit(t *testing.T) {
 		wallet.OnCandle(model.Candle{Time: time.Now(), Symbol: "BTCUSDT", High: 2000, Close: 2000})
 		controller.updateOrders()
 
-		value, profit, err := controller.calculateProfit(&sellOrder[0])
+		value, profit, volume, err := controller.calculateProfit(&sellOrder[0])
 		require.NoError(t, err)
 		assert.Equal(t, 1000.0, value)
 		assert.Equal(t, 1.0, profit)
+		assert.Equal(t, 10750.0, volume)
 	})
 
 	t.Run("oco stop sell", func(t *testing.T) {
@@ -129,9 +133,10 @@ func TestController_calculateProfit(t *testing.T) {
 		wallet.OnCandle(model.Candle{Time: time.Now(), Symbol: "BTCUSDT", Close: 400, Low: 400})
 		controller.updateOrders()
 
-		value, profit, err := controller.calculateProfit(&sellOrder[1])
+		value, profit, volume, err := controller.calculateProfit(&sellOrder[1])
 		require.NoError(t, err)
 		assert.Equal(t, -500.0, value)
 		assert.Equal(t, -0.5, profit)
+		assert.Equal(t, 15750.0, volume)
 	})
 }


### PR DESCRIPTION
Example wallet output with Volume indication:

After producing some profitable strategies I was wondering if volume costs at exchanges
are calculated. I did not find any, other then some taker, maker costs which are not used by the paper-wallet.
The performance of a strategy the volume should be considered.

Maybe an approach with configurable costs for each trade can be created. In reality costs are getting less with more volume a
and are not fixed. So having an indication / approach to the amount of volume is needed to compare strategies.

In below example is a quite "ok" strategy but the volume is so high it takes away much of the profit.

```
+---------+--------+-----+------+--------+--------+----------+-------------+
|  PAIR   | TRADES | WIN | LOSS | % WIN  | PAYOFF |  PROFIT  |   VOLUME    |
+---------+--------+-----+------+--------+--------+----------+-------------+
| ADAUSDT |    795 | 479 |  316 | 60.3 % |  0.859 | 14210.98 | 22762458.98 |
+---------+--------+-----+------+--------+--------+----------+-------------+
|   TOTAL |    795 | 479 |  316 | 60.3 % |  0.859 | 14210.98 | 22762458.98 |
+---------+--------+-----+------+--------+--------+----------+-------------+
--------------
WALLET SUMMARY
--------------
19210.000000 ADA

VOLUMES:
ADAUSDT        = 22809361.82 USDT

11.531500 USDT
--------------
START PORTFOLIO =  10000 USDT
FINAL PORTFOLIO =  24210.97639999994 USDT
GROSS PROFIT    =  14210.976400 USDT (142.11%)
MARKET CHANGE   =  -37.75%
VOLUME          =  22809361.82 USDT
COSTS (0.001*V) =  22809.36 USDT
--------------

```