### PR TITLE
ci: setup codecov and add coverage badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.16
-      - run: go test -race -cover ./...
+      - run: go test -race -coverprofile="coverage.txt" -covermode=atomic ./...
 
       - name: lint
         if: github.event_name == 'pull_request'
@@ -24,3 +24,4 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,3 +19,8 @@ jobs:
           version: latest
           skip-build-cache: true
           skip-pkg-cache: true
+
+      - name: coverage
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 ![image](https://user-images.githubusercontent.com/7620947/119247309-b69d1580-bb5e-11eb-9d81-4495dfc45f21.png)
 
 [![tests](https://github.com/rodrigo-brito/ninjabot/actions/workflows/ci.yaml/badge.svg)](https://github.com/rodrigo-brito/ninjabot/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/rodrigo-brito/ninjabot/branch/main/graph/badge.svg?token=)](https://codecov.io/gh/rodrigo-brito/ninjabot)
 [![Go Reference](https://pkg.go.dev/badge/github.com/rodrigo-brito/ninjabot.svg)](https://pkg.go.dev/github.com/rodrigo-brito/ninjabot)
 
 A fast cryptocurrency trading bot framework implemented in Go. Ninjabot permits users to create and test custom strategies for spot markets. 


### PR DESCRIPTION
Fixes #25. Added codecov coverage as an GitHub action and add a badge in readme.md.
Need to update the `CODECOV_TOKEN` in the repo secrets after enabling it in codecov.