### PR TITLE
feat(download): add progressbar

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -74,7 +74,7 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 	parameters.Start = time.Date(parameters.Start.Year(), parameters.Start.Month(), parameters.Start.Day(),
 		0, 0, 0, 0, time.UTC)
 
-	if time.Now().Sub(parameters.End) > 0 {
+	if now.Sub(parameters.End) > 0 {
 		parameters.End = time.Date(parameters.End.Year(), parameters.End.Month(), parameters.End.Day(),
 			0, 0, 0, 0, time.UTC)
 	} else {

--- a/download/download.go
+++ b/download/download.go
@@ -97,11 +97,11 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 
 	for begin := parameters.Start; begin.Before(parameters.End); begin = begin.Add(interval * batchSize) {
 		end := begin.Add(interval * batchSize)
-		if end.After(parameters.End) {
+		if end.Before(parameters.End) {
+			end = end.Add(-1 * time.Second)
+		} else {
 			end = parameters.End
 			isLastLoop = true
-		} else {
-			end = end.Add(-1 * time.Second)
 		}
 
 		candles, err := d.exchange.CandlesByPeriod(ctx, pair, timeframe, begin, end)

--- a/download/download.go
+++ b/download/download.go
@@ -78,13 +78,16 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 	if err != nil {
 		return err
 	}
+	candlesCount++
 
-	log.Infof("Downloading %d candles of %s for %s", candlesCount+1, timeframe, pair)
+	log.Infof("Downloading %d candles of %s for %s", candlesCount, timeframe, pair)
 	info := d.exchange.AssetsInfo(pair)
 	writer := csv.NewWriter(recordFile)
-	progressBar := progressbar.Default(int64(candlesCount + 1))
+
+	progressBar := progressbar.Default(int64(candlesCount))
 	lostData := 0
 	isLastLoop := false
+
 	for begin := parameters.Start; begin.Before(parameters.End); begin = begin.Add(interval * batchSize) {
 		end := begin.Add(interval * batchSize)
 		if end.After(parameters.End) {
@@ -117,8 +120,12 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 		}
 	}
 
+	if err = progressBar.Close(); err != nil {
+		log.Warningf("close progresbar fail: %s", err.Error())
+	}
+
 	if lostData > 0 {
-		log.Warnf("found lost data %d rows", lostData)
+		log.Warningf("found lost data %d rows", lostData)
 	}
 
 	writer.Flush()

--- a/download/download.go
+++ b/download/download.go
@@ -109,20 +109,19 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 			return err
 		}
 
-		count := 0
 		for _, candle := range candles {
 			err := writer.Write(candle.ToSlice(int(info.PriceDecimalPrecision)))
 			if err != nil {
 				return err
 			}
-			count++
 		}
 
+		countCandles := len(candles)
 		if !isLastLoop {
-			lostData += batchSize - count
+			lostData += batchSize - countCandles
 		}
 
-		if err = progressBar.Add(count); err != nil {
+		if err = progressBar.Add(countCandles); err != nil {
 			log.Warningf("update progresbar fail: %s", err.Error())
 		}
 	}

--- a/download/download.go
+++ b/download/download.go
@@ -3,12 +3,12 @@ package download
 import (
 	"context"
 	"encoding/csv"
-	"github.com/schollz/progressbar/v3"
 	"os"
 	"time"
 
 	"github.com/rodrigo-brito/ninjabot/service"
 
+	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/xhit/go-str2duration/v2"
 )

--- a/download/download.go
+++ b/download/download.go
@@ -74,6 +74,13 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 	parameters.Start = time.Date(parameters.Start.Year(), parameters.Start.Month(), parameters.Start.Day(),
 		0, 0, 0, 0, time.UTC)
 
+	if time.Now().Sub(parameters.End) > 0 {
+		parameters.End = time.Date(parameters.End.Year(), parameters.End.Month(), parameters.End.Day(),
+			0, 0, 0, 0, time.UTC)
+	} else {
+		parameters.End = now
+	}
+
 	candlesCount, interval, err := candlesCount(parameters.Start, parameters.End, timeframe)
 	if err != nil {
 		return err

--- a/download/download.go
+++ b/download/download.go
@@ -87,6 +87,8 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 		end := begin.Add(interval * batchSize)
 		if end.After(parameters.End) {
 			end = parameters.End
+		} else {
+			end = end.Add(-1 * time.Second)
 		}
 
 		candles, err := d.exchange.CandlesByPeriod(ctx, pair, timeframe, begin, end)


### PR DESCRIPTION
### What did not work before?
working on issue #76

### What have you changed and why?
- Include progress bar in download 
- add warning message for lost data
- de-duplicate data by end.Add(-1 * time.Second) because first next loop is look like this one and it the reason why we found duplicate data
- prevent lost data from parameter.End if parameter.End is newer than time.now
- fix wrong candlesCount by add 1 candle because  parameter.Start is 1 candles but was removed by End.Sub(Start)


##### This PR has:

- [x] Been doubled checked by the author
- [x] Tested for newly introduced bugs
- [x] Included documentation

lost data = 2
![h1](https://user-images.githubusercontent.com/34530268/145089703-78bacedd-7cc4-4f5f-a7e7-5c35a39ccc8e.gif)

lost data = 0
![m1](https://user-images.githubusercontent.com/34530268/145089744-174f2be2-7b76-45cf-8390-70142c0a60fb.gif)
