### PR TITLE
fix(queue): include go routine for notifications

### DIFF
--- a/model/priorityqueue.go
+++ b/model/priorityqueue.go
@@ -35,7 +35,7 @@ func (q *PriorityQueue) Push(item Item) {
 	q.up(q.length - 1)
 
 	for _, notify := range q.notifyCallbacks {
-		notify(item)
+		go notify(item)
 	}
 }
 


### PR DESCRIPTION
### What have you changed and why?
Priority queue have a lock in `Push` and `Pop`.  Then, notify must be async to unluck the flow to `PopLock` works

##### Related Issues
Closes https://github.com/rodrigo-brito/ninjabot/issues/126
