### PR TITLE
feat(backtest): include SQN metric

### DIFF
--- a/exchange/paperwallet.go
+++ b/exchange/paperwallet.go
@@ -178,40 +178,38 @@ func (p *PaperWallet) Summary() {
 		volume       float64
 	)
 
-	fmt.Println("--------------")
-	fmt.Println("WALLET SUMMARY")
-	fmt.Println("--------------")
-
+	fmt.Println("-- FINAL WALLET --")
 	for pair, price := range p.avgPrice {
 		asset, quote := SplitAssetQuote(pair)
 		quantity := p.assets[asset].Free + p.assets[asset].Lock
 		total += quantity * price
 		marketChange += (p.lastCandle[pair].Close - p.fistCandle[pair].Close) / p.fistCandle[pair].Close
-		fmt.Printf("%f %s = %f %s\n", quantity, asset, total, quote)
+		fmt.Printf("%.4f %s = %.4f %s\n", quantity, asset, total, quote)
 	}
-
-	fmt.Println()
-	fmt.Println("TRADING VOLUME")
-	for pair, vol := range p.volume {
-		volume += vol
-		fmt.Printf("%s        = %.2f %s\n", pair, vol, p.baseCoin)
-	}
-	fmt.Println()
 
 	avgMarketChange := marketChange / float64(len(p.avgPrice))
 	baseCoinValue := p.assets[p.baseCoin].Free + p.assets[p.baseCoin].Lock
 	profit := total + baseCoinValue - p.initialValue
+	fmt.Printf("%.4f %s\n", baseCoinValue, p.baseCoin)
+	fmt.Println()
 	maxDrawDown, _, _ := p.MaxDrawdown()
-	fmt.Printf("%f %s\n", baseCoinValue, p.baseCoin)
-	fmt.Println("--------------")
-	fmt.Printf("START PORTFOLIO = %.2f %s\n", p.initialValue, p.baseCoin)
-	fmt.Printf("FINAL PORTFOLIO = %.2f %s\n", total+baseCoinValue, p.baseCoin)
-	fmt.Printf("GROSS PROFIT    =  %f %s (%.2f%%)\n", profit, p.baseCoin, profit/p.initialValue*100)
-	fmt.Printf("MARKET (B&H)    =  %.2f%%\n", avgMarketChange*100)
-	fmt.Printf("MAX DRAWDOWN    =  %.2f %%\n", maxDrawDown*100)
-	fmt.Printf("VOLUME          =  %.2f %s\n", volume, p.baseCoin)
-	fmt.Printf("COSTS (0.001*V) =  %.2f %s (ESTIMATION) \n", volume*0.001, p.baseCoin)
-	fmt.Println("--------------")
+	fmt.Println("----- RETURNS -----")
+	fmt.Printf("START PORTFOLIO     = %.2f %s\n", p.initialValue, p.baseCoin)
+	fmt.Printf("FINAL PORTFOLIO     = %.2f %s\n", total+baseCoinValue, p.baseCoin)
+	fmt.Printf("GROSS PROFIT        =  %f %s (%.2f%%)\n", profit, p.baseCoin, profit/p.initialValue*100)
+	fmt.Printf("MARKET CHANGE (B&H) =  %.2f%%\n", avgMarketChange*100)
+	fmt.Println()
+	fmt.Println("------ RISK -------")
+	fmt.Printf("MAX DRAWDOWN = %.2f %%\n", maxDrawDown*100)
+	fmt.Println()
+	fmt.Println("------ VOLUME -----")
+	for pair, vol := range p.volume {
+		volume += vol
+		fmt.Printf("%s         = %.2f %s\n", pair, vol, p.baseCoin)
+	}
+	fmt.Printf("TOTAL           = %.2f %s\n", volume, p.baseCoin)
+	fmt.Printf("COSTS (0.001*V) = %.2f %s (ESTIMATION) \n", volume*0.001, p.baseCoin)
+	fmt.Println("-------------------")
 }
 
 func (p *PaperWallet) lockFunds(asset string, amount float64) error {

--- a/ninjabot.go
+++ b/ninjabot.go
@@ -183,11 +183,12 @@ func (n *NinjaBot) Summary() {
 		wins   int
 		loses  int
 		volume float64
+		sqn    float64
 	)
 
 	buffer := bytes.NewBuffer(nil)
 	table := tablewriter.NewWriter(buffer)
-	table.SetHeader([]string{"Pair", "Trades", "Win", "Loss", "% Win", "Payoff", "Profit", "Volume"})
+	table.SetHeader([]string{"Pair", "Trades", "Win", "Loss", "% Win", "Payoff", "SQN", "Profit", "Volume"})
 	table.SetFooterAlignment(tablewriter.ALIGN_RIGHT)
 	avgPayoff := 0.0
 
@@ -200,10 +201,12 @@ func (n *NinjaBot) Summary() {
 			strconv.Itoa(len(summary.Lose)),
 			fmt.Sprintf("%.1f %%", float64(len(summary.Win))/float64(len(summary.Win)+len(summary.Lose))*100),
 			fmt.Sprintf("%.3f", summary.Payoff()),
+			fmt.Sprintf("%.1f", summary.SQN()),
 			fmt.Sprintf("%.2f", summary.Profit()),
 			fmt.Sprintf("%.2f", summary.Volume),
 		})
 		total += summary.Profit()
+		sqn += summary.SQN()
 		wins += len(summary.Win)
 		loses += len(summary.Lose)
 		volume += summary.Volume
@@ -216,6 +219,7 @@ func (n *NinjaBot) Summary() {
 		strconv.Itoa(loses),
 		fmt.Sprintf("%.1f %%", float64(wins)/float64(wins+loses)*100),
 		fmt.Sprintf("%.3f", avgPayoff/float64(wins+loses)),
+		fmt.Sprintf("%.1f", sqn/float64(len(n.orderController.Results))),
 		fmt.Sprintf("%.2f", total),
 		fmt.Sprintf("%.2f", volume),
 	})

--- a/order/controller.go
+++ b/order/controller.go
@@ -33,6 +33,17 @@ func (s summary) Profit() float64 {
 	return profit
 }
 
+func (s summary) SQN() float64 {
+	total := float64(len(s.Win) + len(s.Lose))
+	avgProfit := s.Profit() / total
+	stdDev := 0.0
+	for _, profit := range append(s.Win, s.Lose...) {
+		stdDev += math.Pow(profit-avgProfit, 2)
+	}
+	stdDev = math.Sqrt(stdDev / total)
+	return math.Sqrt(total) * (s.Profit() / total) / stdDev
+}
+
 func (s summary) Payoff() float64 {
 	avgWin := 0.0
 	avgLose := 0.0


### PR DESCRIPTION
### What have you changed and why?
Include SQN metric for backtest

```
+---------+--------+-----+------+--------+--------+-----+----------+-----------+
|  PAIR   | TRADES | WIN | LOSS | % WIN  | PAYOFF | SQN |  PROFIT  |  VOLUME   |
+---------+--------+-----+------+--------+--------+-----+----------+-----------+
| ETHUSDT |      9 |   6 |    3 | 66.7 % |  3.407 | 1.3 | 21748.41 | 407769.64 |
| BTCUSDT |     14 |   6 |    8 | 42.9 % |  5.929 | 1.5 | 13511.66 | 448030.05 |
+---------+--------+-----+------+--------+--------+-----+----------+-----------+
|   TOTAL |     23 |  12 |   11 | 52.2 % |  4.942 | 1.4 | 35260.07 | 855799.68 |
+---------+--------+-----+------+--------+--------+-----+----------+-----------+
```

##### Related Issues
Closes #136 