### PR TITLE
Fix Heikin-Ashi code  and incorrect test data

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -2,7 +2,7 @@ package model
 
 import (
 	"fmt"
-	"sort"
+	"math"
 	"strconv"
 	"time"
 )
@@ -153,12 +153,6 @@ func (a Account) Equity() float64 {
 func (ha *HeikinAshi) CalculateHeikinAshi(c Candle) Candle {
 	var hkCandle Candle
 
-	highValues := []float64{c.High, c.Open, c.Close}
-	sort.Float64s(highValues)
-
-	lowValues := []float64{c.Low, c.Open, c.Close}
-	sort.Float64s(lowValues)
-
 	openValue := ha.PreviousHACandle.Open
 	closeValue := ha.PreviousHACandle.Close
 
@@ -169,9 +163,9 @@ func (ha *HeikinAshi) CalculateHeikinAshi(c Candle) Candle {
 	}
 
 	hkCandle.Open = (openValue + closeValue) / 2
-	hkCandle.High = highValues[2]
 	hkCandle.Close = (c.Open + c.High + c.Low + c.Close) / 4
-	hkCandle.Low = lowValues[0]
+	hkCandle.High = math.Max(c.High, math.Max(hkCandle.Open, hkCandle.Close))
+	hkCandle.Low = math.Min(c.Low, math.Min(hkCandle.Open, hkCandle.Close))
 	ha.PreviousHACandle = hkCandle
 
 	return hkCandle

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -55,7 +55,7 @@ func TestHeikinAshi_CalculateHeikinAshi(t *testing.T) {
 		t.Errorf("PreviousCandle should be empty")
 	}
 
-	// BTC-USDT weekly candles from Binance from 2017-08-14 to 2017-10-09
+	// BTC-USDT weekly candles from Binance from 2017-08-14 to 2017-10-30
 	// First market candles were used to easily test accuracy against
 	// TradingView without having to download all market data.
 	candles := []Candle{
@@ -68,6 +68,9 @@ func TestHeikinAshi_CalculateHeikinAshi(t *testing.T) {
 		{Open: 3660.02, Close: 4378.48, High: 4406.52, Low: 3653.69},
 		{Open: 4400.00, Close: 4640.00, High: 4658.00, Low: 4110.00},
 		{Open: 4640.00, Close: 5709.99, High: 5922.30, Low: 4550.00},
+		{Open: 5710.00, Close: 5950.02, High: 6171.00, Low: 5037.95},
+		{Open: 5975.00, Close: 6169.98, High: 6189.88, Low: 5286.98},
+		{Open: 6133.01, Close: 7345.01, High: 7590.25, Low: 6030.00},
 	}
 
 	var results []Candle
@@ -82,13 +85,16 @@ func TestHeikinAshi_CalculateHeikinAshi(t *testing.T) {
 	expected := []Candle{
 		{Open: 4173.885, Close: 4170.79, High: 4485.39, Low: 3850},
 		{Open: 4172.3375, Close: 4058.2625000000003, High: 4453.91, Low: 3400},
-		{Open: 4115.3, Close: 4470.705, High: 4939.19, Low: 4124.54},
+		{Open: 4115.3, Close: 4470.705, High: 4939.19, Low: 4115.30},
 		{Open: 4293.0025000000005, Close: 4256.74, High: 4788.59, Low: 3603},
 		{Open: 4274.87125, Close: 3766.2999999999997, High: 4394.59, Low: 2817},
 		{Open: 4020.5856249999997, Close: 3744.6925, High: 4123.2, Low: 3505.55},
 		{Open: 3882.6390625, Close: 4024.6775000000002, High: 4406.52, Low: 3653.69},
-		{Open: 3953.65828125, Close: 4452, High: 4658, Low: 4110},
-		{Open: 4202.829140625, Close: 5205.5725, High: 5922.3, Low: 4550},
+		{Open: 3953.65828125, Close: 4452, High: 4658, Low: 3953.65828125},
+		{Open: 4202.829140625, Close: 5205.5725, High: 5922.3, Low: 4202.829140625},
+		{Open: 4704.200820312501, Close: 5717.2425, High: 6171.00, Low: 4704.200820312501},
+		{Open: 5210.72166015625, Close: 5905.46, High: 6189.88, Low: 5210.72166015625},
+		{Open: 5558.090830078125, Close: 6774.567500000001, High: 7590.25, Low: 5558.090830078125},
 	}
 
 	if len(expected) != len(results) {


### PR DESCRIPTION
The Heikin-Ashi implementation should determine High and Low based on the calculated HK open en HK close.
When implemented correctly this way the test case fails. Turns out the test data does **NOT** match the actual data in TradingView when looking at the Heikin-Ashi candles from the start of trading in 2017.

### What have you changed and why?
Fixed the Heikin-Ashi implementation
Entered the correct test data from TradingView, (publicly available information, feel free to verify)
