### PR TITLE
feat(indicator): include indicators from strategies

### DIFF
--- a/examples/backtesting/main.go
+++ b/examples/backtesting/main.go
@@ -54,11 +54,14 @@ func main() {
 		exchange.WithDataFeed(csvFeed),
 	)
 
-	chart, err := plot.NewChart(plot.WithIndicators(
-		indicator.EMA(8, "red"),
-		indicator.SMA(21, "#000"),
-		indicator.RSI(14, "purple"),
-	), plot.WithPaperWallet(wallet))
+	chart, err := plot.NewChart(
+		plot.WithStrategyIndicators(strategy),
+		plot.WithCustomIndicators(
+			indicator.RSI(14, "purple"),
+			indicator.Stoch(8, 3, 3, "red", "blue"),
+		),
+		plot.WithPaperWallet(wallet),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/paperwallet/main.go
+++ b/examples/paperwallet/main.go
@@ -62,7 +62,7 @@ func main() {
 	strategy := new(strategies.CrossEMA)
 
 	chart, err := plot.NewChart(
-		plot.WithIndicators(
+		plot.WithCustomIndicators(
 			indicator.EMA(8, "red"),
 			indicator.SMA(21, "blue"),
 		),

--- a/examples/strategies/emacross.go
+++ b/examples/strategies/emacross.go
@@ -3,6 +3,7 @@ package strategies
 import (
 	"github.com/rodrigo-brito/ninjabot"
 	"github.com/rodrigo-brito/ninjabot/service"
+	"github.com/rodrigo-brito/ninjabot/strategy"
 
 	"github.com/markcheno/go-talib"
 	log "github.com/sirupsen/logrus"
@@ -18,9 +19,31 @@ func (e CrossEMA) WarmupPeriod() int {
 	return 21
 }
 
-func (e CrossEMA) Indicators(df *ninjabot.Dataframe) {
+func (e CrossEMA) Indicators(df *ninjabot.Dataframe) []strategy.ChartIndicator {
 	df.Metadata["ema8"] = talib.Ema(df.Close, 8)
 	df.Metadata["sma21"] = talib.Sma(df.Close, 21)
+
+	return []strategy.ChartIndicator{
+		{
+			Overlay:   true,
+			GroupName: "MA's",
+			Time:      df.Time,
+			Metrics: []strategy.IndicatorMetric{
+				{
+					Values: df.Metadata["ema8"],
+					Name:   "EMA 8",
+					Color:  "red",
+					Style:  strategy.StyleLine,
+				},
+				{
+					Values: df.Metadata["sma21"],
+					Name:   "SMA 21",
+					Color:  "blue",
+					Style:  strategy.StyleLine,
+				},
+			},
+		},
+	}
 }
 
 func (e *CrossEMA) OnCandle(df *ninjabot.Dataframe, broker service.Broker) {

--- a/examples/strategies/ocosell.go
+++ b/examples/strategies/ocosell.go
@@ -3,6 +3,7 @@ package strategies
 import (
 	"github.com/rodrigo-brito/ninjabot/model"
 	"github.com/rodrigo-brito/ninjabot/service"
+	"github.com/rodrigo-brito/ninjabot/strategy"
 
 	"github.com/markcheno/go-talib"
 	log "github.com/sirupsen/logrus"
@@ -18,7 +19,7 @@ func (e OCOSell) WarmupPeriod() int {
 	return 9
 }
 
-func (e OCOSell) Indicators(df *model.Dataframe) {
+func (e OCOSell) Indicators(df *model.Dataframe) []strategy.ChartIndicator {
 	df.Metadata["stoch"], df.Metadata["stoch_signal"] = talib.Stoch(
 		df.High,
 		df.Low,
@@ -29,6 +30,8 @@ func (e OCOSell) Indicators(df *model.Dataframe) {
 		3,
 		talib.SMA,
 	)
+
+	return nil
 }
 
 func (e *OCOSell) OnCandle(df *model.Dataframe, broker service.Broker) {

--- a/examples/strategies/turtle.go
+++ b/examples/strategies/turtle.go
@@ -3,6 +3,7 @@ package strategies
 import (
 	"github.com/rodrigo-brito/ninjabot"
 	"github.com/rodrigo-brito/ninjabot/service"
+	"github.com/rodrigo-brito/ninjabot/strategy"
 
 	"github.com/markcheno/go-talib"
 	log "github.com/sirupsen/logrus"
@@ -19,9 +20,11 @@ func (e Turtle) WarmupPeriod() int {
 	return 40
 }
 
-func (e Turtle) Indicators(df *ninjabot.Dataframe) {
+func (e Turtle) Indicators(df *ninjabot.Dataframe) []strategy.ChartIndicator {
 	df.Metadata["turtleHighest"] = talib.Max(df.Close, 40)
 	df.Metadata["turtleLowest"] = talib.Min(df.Close, 20)
+
+	return nil
 }
 
 func (e *Turtle) OnCandle(df *ninjabot.Dataframe, broker service.Broker) {

--- a/ninjabot_test.go
+++ b/ninjabot_test.go
@@ -2,6 +2,7 @@ package ninjabot
 
 import (
 	"context"
+	"github.com/rodrigo-brito/ninjabot/strategy"
 	"testing"
 
 	"github.com/markcheno/go-talib"
@@ -23,8 +24,9 @@ func (e fakeStrategy) WarmupPeriod() int {
 	return 9
 }
 
-func (e fakeStrategy) Indicators(df *Dataframe) {
+func (e fakeStrategy) Indicators(df *Dataframe) []strategy.ChartIndicator {
 	df.Metadata["ema9"] = talib.Ema(df.Close, 9)
+	return nil
 }
 
 func (e *fakeStrategy) OnCandle(df *Dataframe, broker service.Broker) {

--- a/plot/chart.go
+++ b/plot/chart.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rodrigo-brito/ninjabot/exchange"
 	"github.com/rodrigo-brito/ninjabot/model"
+	"github.com/rodrigo-brito/ninjabot/strategy"
 
 	"github.com/StudioSol/set"
 	"github.com/evanw/esbuild/pkg/api"
@@ -38,6 +39,7 @@ type Chart struct {
 	paperWallet   *exchange.PaperWallet
 	scriptContent string
 	indexHTML     *template.Template
+	strategy      strategy.Strategy
 }
 
 type Candle struct {
@@ -188,6 +190,30 @@ func (c *Chart) indicatorsByPair(pair string) []plotIndicator {
 
 		indicators = append(indicators, indicator)
 	}
+
+	if c.strategy != nil {
+		warmup := c.strategy.WarmupPeriod()
+		strategyIndicators := c.strategy.Indicators(c.dataframe[pair])
+		for _, i := range strategyIndicators {
+			indicator := plotIndicator{
+				Name:    i.GroupName,
+				Overlay: i.Overlay,
+				Metrics: make([]indicatorMetric, 0),
+			}
+
+			for _, metric := range i.Metrics {
+				indicator.Metrics = append(indicator.Metrics, indicatorMetric{
+					Time:   i.Time[warmup:],
+					Values: metric.Values[warmup:],
+					Name:   metric.Name,
+					Color:  metric.Color,
+					Style:  metric.Style,
+				})
+			}
+			indicators = append(indicators, indicator)
+		}
+	}
+
 	return indicators
 }
 
@@ -375,6 +401,12 @@ func WithPort(port int) Option {
 	}
 }
 
+func WithStrategyIndicators(strategy strategy.Strategy) Option {
+	return func(chart *Chart) {
+		chart.strategy = strategy
+	}
+}
+
 func WithPaperWallet(paperWallet *exchange.PaperWallet) Option {
 	return func(chart *Chart) {
 		chart.paperWallet = paperWallet
@@ -388,7 +420,7 @@ func WithDebug() Option {
 	}
 }
 
-func WithIndicators(indicators ...Indicator) Option {
+func WithCustomIndicators(indicators ...Indicator) Option {
 	return func(chart *Chart) {
 		chart.indicators = indicators
 	}

--- a/plot/chart.go
+++ b/plot/chart.go
@@ -207,7 +207,7 @@ func (c *Chart) indicatorsByPair(pair string) []plotIndicator {
 					Values: metric.Values[warmup:],
 					Name:   metric.Name,
 					Color:  metric.Color,
-					Style:  metric.Style,
+					Style:  string(metric.Style),
 				})
 			}
 			indicators = append(indicators, indicator)

--- a/plot/chart_test.go
+++ b/plot/chart_test.go
@@ -171,7 +171,7 @@ func TestChart_WithDebug(t *testing.T) {
 
 func TestChart_WithIndicator(t *testing.T) {
 	var indicator []Indicator
-	c, err := NewChart(WithIndicators(indicator...))
+	c, err := NewChart(WithCustomIndicators(indicator...))
 	require.NoErrorf(t, err, "error when initial chart")
 	require.Equal(t, indicator, c.indicators)
 }

--- a/strategy/indicator.go
+++ b/strategy/indicator.go
@@ -1,0 +1,30 @@
+package strategy
+
+import (
+	"github.com/rodrigo-brito/ninjabot/model"
+	"time"
+)
+
+type MetricStyle string
+
+const (
+	StyleBar       = "bar"
+	StyleScatter   = "scatter"
+	StyleLine      = "line"
+	StyleHistogram = "histogram"
+	StyleWaterfall = "waterfall"
+)
+
+type IndicatorMetric struct {
+	Name   string
+	Color  string
+	Style  MetricStyle // default: line
+	Values model.Series
+}
+
+type ChartIndicator struct {
+	Time      []time.Time
+	Metrics   []IndicatorMetric
+	Overlay   bool
+	GroupName string
+}

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -12,7 +12,7 @@ type Strategy interface {
 	// This time is measured in the period specified in the `Timeframe` function.
 	WarmupPeriod() int
 	// Indicators will be executed for each new candle, in order to fill indicators before `OnCandle` function is called.
-	Indicators(df *model.Dataframe)
+	Indicators(df *model.Dataframe) []ChartIndicator
 	// OnCandle will be executed for each new candle, after indicators are filled, here you can do your trading logic.
 	// OnCandle is executed after the candle close.
 	OnCandle(df *model.Dataframe, broker service.Broker)


### PR DESCRIPTION
Now, its possible to include indicators in the chart visualization directly from strategy:

Example:
```go
chart, err := plot.NewChart(
		plot.WithStrategyIndicators(strategy),
)
```

```go
func (m MyCustomStrategy) Indicators(df *ninjabot.Dataframe) []strategy.ChartIndicator {
	df.Metadata["ema8"] = talib.Ema(df.Close, 8)
	df.Metadata["sma21"] = talib.Sma(df.Close, 21)

	return []strategy.ChartIndicator{
		{
			Overlay:   true,
			GroupName: "MA",
			Time:      df.Time,
			Metrics: []strategy.IndicatorMetric{
				{
					Values: df.Metadata["ema8"],
					Name:   "EMA 8",
					Color:  "red",
					Style:  strategy.StyleLine,
				},
				{
					Values: df.Metadata["sma21"],
					Name:   "SMA 21",
					Color:  "blue",
					Style:  strategy.StyleLine,
				},
			},
		},
	}
}
````
