### PR TITLE
Fix backtest  errors; enforce QtyDecimalPrecision

### DIFF
--- a/exchange/paperwallet.go
+++ b/exchange/paperwallet.go
@@ -524,11 +524,14 @@ func (p *PaperWallet) createOrderMarket(side model.SideType, pair string, size f
 }
 
 func (p *PaperWallet) CreateOrderMarketQuote(side model.SideType, pair string,
-	quantity float64) (model.Order, error) {
+	quoteQuantity float64) (model.Order, error) {
 	p.Lock()
 	defer p.Unlock()
 
-	return p.createOrderMarket(side, pair, quantity/p.lastCandle[pair].Close)
+	quantity := quoteQuantity / p.lastCandle[pair].Close
+	places := math.Pow10(int(p.AssetsInfo(pair).QtyDecimalPrecision))
+	quantity = math.Floor(quantity*places) / places
+	return p.createOrderMarket(side, pair, quantity)
 }
 
 func (p *PaperWallet) Cancel(order model.Order) error {


### PR DESCRIPTION
For me, when I do

`go run ./examples/backtesting` 

I get the following:

![Screenshot 2022-07-12 at 22 22 49](https://user-images.githubusercontent.com/1306351/178588020-5d521eb1-7291-461f-9a2e-33a2a7fc2bee.png)

This seems to be caused by rounding errors in market orders. 
My fix enforces QtyDecimalPrecision and this gets rid of the errors.
