### PR TITLE
fix(binance): ajust order size format

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -110,7 +110,7 @@ func (d Downloader) Download(ctx context.Context, pair, timeframe string, output
 		}
 
 		for _, candle := range candles {
-			err := writer.Write(candle.ToSlice(int(info.PriceDecimalPrecision)))
+			err := writer.Write(candle.ToSlice(info.QuotePrecision))
 			if err != nil {
 				return err
 			}

--- a/exchange/binance_test.go
+++ b/exchange/binance_test.go
@@ -1,0 +1,42 @@
+package exchange
+
+import (
+	"fmt"
+	"github.com/rodrigo-brito/ninjabot/model"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFormatQuantity(t *testing.T) {
+	binance := Binance{assetsInfo: map[string]model.AssetInfo{
+		"BTCUSDT": {
+			StepSize:           0.00001000,
+			BaseAssetPrecision: 5,
+			QuotePrecision:     5,
+		},
+		"BATUSDT": {
+			StepSize:           0.01,
+			BaseAssetPrecision: 2,
+			QuotePrecision:     2,
+		},
+	}}
+
+	tt := []struct {
+		pair     string
+		quantity float64
+		expected string
+	}{
+		{"BTCUSDT", 1.1, "1.1"},
+		{"BTCUSDT", 11, "11"},
+		{"BTCUSDT", 1.1111111111, "1.11111"},
+		{"BTCUSDT", 1111111.1111111111, "1111111.11111"},
+		{"BATUSDT", 111.111, "111.11"},
+		{"BATUSDT", 9.99999, "9.99"},
+	}
+
+	for _, tc := range tt {
+		t.Run(fmt.Sprintf("given %f %s", tc.quantity, tc.pair), func(t *testing.T) {
+			require.Equal(t, tc.expected, binance.formatQuantity(tc.pair, tc.quantity))
+		})
+	}
+}

--- a/exchange/binance_test.go
+++ b/exchange/binance_test.go
@@ -11,11 +11,13 @@ func TestFormatQuantity(t *testing.T) {
 	binance := Binance{assetsInfo: map[string]model.AssetInfo{
 		"BTCUSDT": {
 			StepSize:           0.00001000,
+			TickSize:           0.00001000,
 			BaseAssetPrecision: 5,
 			QuotePrecision:     5,
 		},
 		"BATUSDT": {
 			StepSize:           0.01,
+			TickSize:           0.01,
 			BaseAssetPrecision: 2,
 			QuotePrecision:     2,
 		},
@@ -37,6 +39,7 @@ func TestFormatQuantity(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(fmt.Sprintf("given %f %s", tc.quantity, tc.pair), func(t *testing.T) {
 			require.Equal(t, tc.expected, binance.formatQuantity(tc.pair, tc.quantity))
+			require.Equal(t, tc.expected, binance.formatPrice(tc.pair, tc.quantity))
 		})
 	}
 }

--- a/exchange/csvfeed.go
+++ b/exchange/csvfeed.go
@@ -31,14 +31,14 @@ type CSVFeed struct {
 func (c CSVFeed) AssetsInfo(pair string) model.AssetInfo {
 	asset, quote := SplitAssetQuote(pair)
 	return model.AssetInfo{
-		BaseAsset:             asset,
-		QuoteAsset:            quote,
-		MaxPrice:              math.MaxFloat64,
-		MaxQuantity:           math.MaxFloat64,
-		StepSize:              0.00000001,
-		TickSize:              0.00000001,
-		QtyDecimalPrecision:   8,
-		PriceDecimalPrecision: 8,
+		BaseAsset:          asset,
+		QuoteAsset:         quote,
+		MaxPrice:           math.MaxFloat64,
+		MaxQuantity:        math.MaxFloat64,
+		StepSize:           0.00000001,
+		TickSize:           0.00000001,
+		QuotePrecision:     8,
+		BaseAssetPrecision: 8,
 	}
 }
 

--- a/exchange/paperwallet.go
+++ b/exchange/paperwallet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/adshao/go-binance/v2/common"
 	"math"
 	"strings"
 	"sync"
@@ -47,14 +48,14 @@ type PaperWallet struct {
 func (p *PaperWallet) AssetsInfo(pair string) model.AssetInfo {
 	asset, quote := SplitAssetQuote(pair)
 	return model.AssetInfo{
-		BaseAsset:             asset,
-		QuoteAsset:            quote,
-		MaxPrice:              math.MaxFloat64,
-		MaxQuantity:           math.MaxFloat64,
-		StepSize:              0.00000001,
-		TickSize:              0.00000001,
-		QtyDecimalPrecision:   8,
-		PriceDecimalPrecision: 8,
+		BaseAsset:          asset,
+		QuoteAsset:         quote,
+		MaxPrice:           math.MaxFloat64,
+		MaxQuantity:        math.MaxFloat64,
+		StepSize:           0.00000001,
+		TickSize:           0.00000001,
+		QuotePrecision:     8,
+		BaseAssetPrecision: 8,
 	}
 }
 
@@ -528,9 +529,8 @@ func (p *PaperWallet) CreateOrderMarketQuote(side model.SideType, pair string,
 	p.Lock()
 	defer p.Unlock()
 
-	quantity := quoteQuantity / p.lastCandle[pair].Close
-	places := math.Pow10(int(p.AssetsInfo(pair).QtyDecimalPrecision))
-	quantity = math.Floor(quantity*places) / places
+	info := p.AssetsInfo(pair)
+	quantity := common.AmountToLotSize(info.StepSize, info.BaseAssetPrecision, quoteQuantity/p.lastCandle[pair].Close)
 	return p.createOrderMarket(side, pair, quantity)
 }
 

--- a/exchange/paperwallet.go
+++ b/exchange/paperwallet.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/adshao/go-binance/v2/common"
 	"math"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/adshao/go-binance/v2/common"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/rodrigo-brito/ninjabot/model"

--- a/exchange/paperwallet_test.go
+++ b/exchange/paperwallet_test.go
@@ -292,7 +292,7 @@ func TestPaperWallet_MaxDrawndown(t *testing.T) {
 func TestPaperWallet_AssetsInfo(t *testing.T) {
 	wallet := PaperWallet{}
 	info := wallet.AssetsInfo("BTCUSDT")
-	require.Equal(t, info.PriceDecimalPrecision, int64(8))
+	require.Equal(t, info.QuotePrecision, 8)
 	require.Equal(t, info.BaseAsset, "BTC")
 	require.Equal(t, info.QuoteAsset, "USDT")
 }

--- a/model/model.go
+++ b/model/model.go
@@ -35,9 +35,8 @@ type AssetInfo struct {
 	StepSize    float64
 	TickSize    float64
 
-	// Number of decimal places
-	QtyDecimalPrecision   int64
-	PriceDecimalPrecision int64
+	QuotePrecision     int
+	BaseAssetPrecision int
 }
 
 type Dataframe struct {


### PR DESCRIPTION
As discussed at https://github.com/rodrigo-brito/ninjabot/pull/170#issuecomment-1182765438
Binace provides a function to format order sizer with price filters

### What have you changed and why?
Replace the format function with binance commons function

Ref https://github.com/rodrigo-brito/ninjabot/pull/170

Closes https://github.com/rodrigo-brito/ninjabot/issues/172