### PR TITLE
feat(tools): create trailing stop and order scheduler

### DIFF
--- a/examples/backtesting/main.go
+++ b/examples/backtesting/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	ctx := context.Background()
 
+	// bot settings (eg: pairs, telegram, etc)
 	settings := ninjabot.Settings{
 		Pairs: []string{
 			"BTCUSDT",
@@ -23,8 +24,10 @@ func main() {
 		},
 	}
 
+	// initialize your strategy
 	strategy := new(strategies.CrossEMA)
 
+	// load historical data from CSV files
 	csvFeed, err := exchange.NewCSVFeed(
 		strategy.Timeframe(),
 		exchange.PairFeed{
@@ -42,11 +45,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// initialize a database in memory
 	storage, err := storage.FromMemory()
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// create a paper wallet for simulation, initializing with 10.000 USDT
 	wallet := exchange.NewPaperWallet(
 		ctx,
 		"USDT",
@@ -54,11 +59,11 @@ func main() {
 		exchange.WithDataFeed(csvFeed),
 	)
 
+	// create a chart  with indicators from the strategy and a custom additional RSI indicator
 	chart, err := plot.NewChart(
 		plot.WithStrategyIndicators(strategy),
 		plot.WithCustomIndicators(
 			indicator.RSI(14, "purple"),
-			indicator.Stoch(8, 3, 3, "red", "blue"),
 		),
 		plot.WithPaperWallet(wallet),
 	)
@@ -66,21 +71,24 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// initializer Ninjabot with the objects created before
 	bot, err := ninjabot.NewBot(
 		ctx,
 		settings,
 		wallet,
 		strategy,
-		ninjabot.WithBacktest(wallet),
+		ninjabot.WithBacktest(wallet), // Required for Backtest mode
 		ninjabot.WithStorage(storage),
+
+		// connect bot feed (candle and orders) to the chart
 		ninjabot.WithCandleSubscription(chart),
 		ninjabot.WithOrderSubscription(chart),
-		ninjabot.WithLogLevel(log.WarnLevel),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// Initializer simulation
 	err = bot.Run(ctx)
 	if err != nil {
 		log.Fatal(err)
@@ -89,7 +97,7 @@ func main() {
 	// Print bot results
 	bot.Summary()
 
-	// Display candlesticks chart in browser
+	// Display candlesticks chart in local browser
 	err = chart.Start()
 	if err != nil {
 		log.Fatal(err)

--- a/examples/strategies/ocosell.go
+++ b/examples/strategies/ocosell.go
@@ -31,7 +31,27 @@ func (e OCOSell) Indicators(df *model.Dataframe) []strategy.ChartIndicator {
 		talib.SMA,
 	)
 
-	return nil
+	return []strategy.ChartIndicator{
+		{
+			Overlay:   false,
+			GroupName: "Stochastic",
+			Time:      df.Time,
+			Metrics: []strategy.IndicatorMetric{
+				{
+					Values: df.Metadata["stoch"],
+					Name:   "K",
+					Color:  "red",
+					Style:  strategy.StyleLine,
+				},
+				{
+					Values: df.Metadata["stoch_signal"],
+					Name:   "D",
+					Color:  "blue",
+					Style:  strategy.StyleLine,
+				},
+			},
+		},
+	}
 }
 
 func (e *OCOSell) OnCandle(df *model.Dataframe, broker service.Broker) {

--- a/examples/strategies/trailingstop.go
+++ b/examples/strategies/trailingstop.go
@@ -1,0 +1,86 @@
+package strategies
+
+import (
+	"github.com/markcheno/go-talib"
+	"github.com/rodrigo-brito/ninjabot"
+	"github.com/rodrigo-brito/ninjabot/model"
+	"github.com/rodrigo-brito/ninjabot/service"
+	"github.com/rodrigo-brito/ninjabot/strategy"
+	"github.com/rodrigo-brito/ninjabot/tools"
+	log "github.com/sirupsen/logrus"
+)
+
+type trailing struct {
+	trailingStop map[string]*tools.TrailingStop
+	scheduler    map[string]*tools.Scheduler
+}
+
+func NewTrailing(pairs []string) strategy.HighFrequencyStrategy {
+	strategy := &trailing{
+		trailingStop: make(map[string]*tools.TrailingStop),
+		scheduler:    make(map[string]*tools.Scheduler),
+	}
+
+	for _, pair := range pairs {
+		strategy.trailingStop[pair] = tools.NewTrailingStop()
+		strategy.scheduler[pair] = tools.NewScheduler(pair)
+	}
+
+	return strategy
+}
+
+func (t trailing) Timeframe() string {
+	return "4h"
+}
+
+func (t trailing) WarmupPeriod() int {
+	return 21
+}
+
+func (t trailing) Indicators(df *model.Dataframe) []strategy.ChartIndicator {
+	df.Metadata["ema_fast"] = talib.Ema(df.Close, 8)
+	df.Metadata["sma_slow"] = talib.Sma(df.Close, 21)
+
+	return nil
+}
+
+func (t trailing) OnCandle(df *model.Dataframe, broker service.Broker) {
+	asset, quote, err := broker.Position(df.Pair)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	if quote > 10.0 && // enough cash?
+		asset*df.Close.Last(0) < 10 && // without position yet
+		df.Metadata["ema_fast"].Crossover(df.Metadata["sma_slow"]) {
+		_, err = broker.CreateOrderMarketQuote(ninjabot.SideTypeBuy, df.Pair, quote)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		t.trailingStop[df.Pair].Start(df.Close.Last(0), df.Low.Last(0))
+
+		return
+	}
+}
+
+func (t trailing) OnPartialCandle(df *model.Dataframe, broker service.Broker) {
+	if trailing := t.trailingStop[df.Pair]; trailing != nil && trailing.Update(df.Close.Last(0)) {
+		asset, _, err := broker.Position(df.Pair)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		if asset > 0 {
+			_, err = broker.CreateOrderMarket(ninjabot.SideTypeSell, df.Pair, asset)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			trailing.Stop()
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rodrigo-brito/ninjabot
 
-go 1.17
+go 1.18
 
 require (
 	github.com/StudioSol/set v0.0.0-20211001132805-52fe71d0afcf
@@ -9,6 +9,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/markcheno/go-talib v0.0.0-20190307022042-cd53a9264d70
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/samber/lo v1.25.0
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
@@ -42,8 +43,8 @@ require (
 	github.com/tidwall/tinyqueue v0.1.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/StudioSol/set v0.0.0-20211001132805-52fe71d0afcf h1:J0UFkeov8c7HXBx/9LT0k5NZgUMXQWnl9o3B15Qja5w=
 github.com/StudioSol/set v0.0.0-20211001132805-52fe71d0afcf/go.mod h1:gHtdo3acqCLmt09I95lUZsaYbD5EkgaXXb/+IRbU3jg=
 github.com/adshao/go-binance/v2 v2.3.6 h1:aGmMczrtscRCGV3WESoWmZXEAL4NwbHQUTzv7J4swC4=
@@ -43,6 +42,7 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -56,6 +56,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.25.0 h1:H8F6cB0RotRdgcRCivTByAQePaYhGMdOTJIj2QFS2I0=
+github.com/samber/lo v1.25.0/go.mod h1:2I7tgIv8Q1SG2xEIkRq0F2i2zgxVpnyPOP0d3Gj2r+A=
 github.com/schollz/progressbar/v3 v3.8.6 h1:QruMUdzZ1TbEP++S1m73OqRJk20ON11m6Wqv4EoGg8c=
 github.com/schollz/progressbar/v3 v3.8.6/go.mod h1:W5IEwbJecncFGBvuEh4A7HT1nZZ6WNIL2i3qbnI0WKY=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
@@ -71,6 +73,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tidwall/assert v0.1.0 h1:aWcKyRBUAdLoVebxo95N7+YZVTFF/ASTr7BN4sLP6XI=
 github.com/tidwall/assert v0.1.0/go.mod h1:QLYtGyeqse53vuELQheYl9dngGCJQ+mTtlxcktb+Kj8=
 github.com/tidwall/btree v1.1.0 h1:5P+9WU8ui5uhmcg3SoPyTwoI0mVyZ1nps7YQzTZFkYM=
@@ -99,6 +102,8 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRT
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -112,11 +117,10 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/tucnak/telebot.v2 v2.5.0 h1:i+NynLo443Vp+Zn3Gv9JBjh3Z/PaiKAQwcnhNI7y6Po=
 gopkg.in/tucnak/telebot.v2 v2.5.0/go.mod h1:BgaIIx50PSRS9pG59JH+geT82cfvoJU/IaI5TJdN3v8=

--- a/readme.md
+++ b/readme.md
@@ -103,10 +103,11 @@ Chart available at http://localhost:8080
   - [x] Plot (Candles + Sell / Buy orders, Indicators)
   - [x] Telegram Controller (Status, Buy, Sell, and Notification)
   - [x] Heikin Ashi candle type support
+  - [x] Trailing stop tool
+  - [x] In app order scheduler
 
 # Roadmap
   - [ ] Include Web UI Controller
-  - [ ] Include trailing stop tool
   - [ ] Include more chart indicators - [Details](https://github.com/rodrigo-brito/ninjabot/issues/110)
   - [ ] Support future market - [Details](https://github.com/rodrigo-brito/ninjabot/issues/106)
 

--- a/tools/scheduler.go
+++ b/tools/scheduler.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"github.com/rodrigo-brito/ninjabot"
+	"github.com/rodrigo-brito/ninjabot/service"
+	"github.com/samber/lo"
+	log "github.com/sirupsen/logrus"
+)
+
+type OrderCondition struct {
+	Condition func(df *ninjabot.Dataframe) bool
+	Size      float64
+	Side      ninjabot.SideType
+}
+
+type Scheduler struct {
+	pair            string
+	orderConditions []OrderCondition
+}
+
+func NewScheduler(pair string) *Scheduler {
+	return &Scheduler{pair: pair}
+}
+
+func (s *Scheduler) SellWhen(size float64, condition func(df *ninjabot.Dataframe) bool) {
+	s.orderConditions = append(s.orderConditions, OrderCondition{Condition: condition, Size: size, Side: ninjabot.SideTypeSell})
+}
+
+func (s *Scheduler) BuyWhen(size float64, condition func(df *ninjabot.Dataframe) bool) {
+	s.orderConditions = append(s.orderConditions, OrderCondition{Condition: condition, Size: size, Side: ninjabot.SideTypeSell})
+}
+
+func (s *Scheduler) Update(df *ninjabot.Dataframe, broker service.Broker) {
+	s.orderConditions = lo.Filter[OrderCondition](s.orderConditions, func(oc OrderCondition, _ int) bool {
+		if oc.Condition(df) {
+			_, err := broker.CreateOrderMarket(oc.Side, s.pair, oc.Size)
+			if err != nil {
+				log.Error(err)
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/tools/trailing.go
+++ b/tools/trailing.go
@@ -1,0 +1,40 @@
+package tools
+
+type TrailingStop struct {
+	current float64
+	stop    float64
+	active  bool
+}
+
+func NewTrailingStop() *TrailingStop {
+	return &TrailingStop{}
+}
+
+func (t *TrailingStop) Start(current, stop float64) {
+	t.stop = stop
+	t.current = current
+	t.active = true
+}
+
+func (t *TrailingStop) Stop() {
+	t.active = false
+}
+
+func (t TrailingStop) Active() bool {
+	return t.active
+}
+
+func (t *TrailingStop) Update(current float64) bool {
+	if !t.active {
+		return false
+	}
+
+	if current > t.current {
+		t.stop = t.stop + (current - t.current)
+		t.current = current
+		return false
+	}
+
+	t.current = current
+	return current <= t.stop
+}


### PR DESCRIPTION
Example of usage:

Initialization
```go
traillingstop := tools.NewTrailingStop()
```

Start traillingstop:
```go
traillingstop.Start(df.Close.Last(0), df.Low.Last(0)) // will accept a downside until the lowest value of the candle
```

Trailling stop must be updated in the OnPartialCandle (triggered every 2 seconds)
```go
func (t trailing) OnPartialCandle(df *model.Dataframe, broker service.Broker) {
	if trailing := t.trailingStop[df.Pair]; trailing != nil && trailing.Update(df.Close.Last(0)) {
		asset, _, err := broker.Position(df.Pair)
		if err != nil {
			log.Error(err)
			return
		}

		if asset > 0 {
			_, err = broker.CreateOrderMarket(ninjabot.SideTypeSell, df.Pair, asset)
			if err != nil {
				log.Error(err)
				return
			}
			trailing.Stop()
		}
	}
}
```


##### Related Issues
Closes #140 