### PR TITLE
feat(indicator): include indicator module

### DIFF
--- a/examples/strategies/emacross.go
+++ b/examples/strategies/emacross.go
@@ -2,10 +2,10 @@ package strategies
 
 import (
 	"github.com/rodrigo-brito/ninjabot"
+	"github.com/rodrigo-brito/ninjabot/indicator"
 	"github.com/rodrigo-brito/ninjabot/service"
 	"github.com/rodrigo-brito/ninjabot/strategy"
 
-	"github.com/markcheno/go-talib"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -20,8 +20,8 @@ func (e CrossEMA) WarmupPeriod() int {
 }
 
 func (e CrossEMA) Indicators(df *ninjabot.Dataframe) []strategy.ChartIndicator {
-	df.Metadata["ema8"] = talib.Ema(df.Close, 8)
-	df.Metadata["sma21"] = talib.Sma(df.Close, 21)
+	df.Metadata["ema8"] = indicator.EMA(df.Close, 8)
+	df.Metadata["sma21"] = indicator.SMA(df.Close, 21)
 
 	return []strategy.ChartIndicator{
 		{

--- a/examples/strategies/ocosell.go
+++ b/examples/strategies/ocosell.go
@@ -1,11 +1,12 @@
 package strategies
 
 import (
+	"github.com/markcheno/go-talib"
+	"github.com/rodrigo-brito/ninjabot/indicator"
 	"github.com/rodrigo-brito/ninjabot/model"
 	"github.com/rodrigo-brito/ninjabot/service"
 	"github.com/rodrigo-brito/ninjabot/strategy"
 
-	"github.com/markcheno/go-talib"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -20,7 +21,7 @@ func (e OCOSell) WarmupPeriod() int {
 }
 
 func (e OCOSell) Indicators(df *model.Dataframe) []strategy.ChartIndicator {
-	df.Metadata["stoch"], df.Metadata["stoch_signal"] = talib.Stoch(
+	df.Metadata["stoch"], df.Metadata["stoch_signal"] = indicator.Stoch(
 		df.High,
 		df.Low,
 		df.Close,

--- a/examples/strategies/trailingstop.go
+++ b/examples/strategies/trailingstop.go
@@ -1,12 +1,13 @@
 package strategies
 
 import (
-	"github.com/markcheno/go-talib"
 	"github.com/rodrigo-brito/ninjabot"
+	"github.com/rodrigo-brito/ninjabot/indicator"
 	"github.com/rodrigo-brito/ninjabot/model"
 	"github.com/rodrigo-brito/ninjabot/service"
 	"github.com/rodrigo-brito/ninjabot/strategy"
 	"github.com/rodrigo-brito/ninjabot/tools"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,8 +39,8 @@ func (t trailing) WarmupPeriod() int {
 }
 
 func (t trailing) Indicators(df *model.Dataframe) []strategy.ChartIndicator {
-	df.Metadata["ema_fast"] = talib.Ema(df.Close, 8)
-	df.Metadata["sma_slow"] = talib.Sma(df.Close, 21)
+	df.Metadata["ema_fast"] = indicator.EMA(df.Close, 8)
+	df.Metadata["sma_slow"] = indicator.SMA(df.Close, 21)
 
 	return nil
 }

--- a/examples/strategies/turtle.go
+++ b/examples/strategies/turtle.go
@@ -2,10 +2,10 @@ package strategies
 
 import (
 	"github.com/rodrigo-brito/ninjabot"
+	"github.com/rodrigo-brito/ninjabot/indicator"
 	"github.com/rodrigo-brito/ninjabot/service"
 	"github.com/rodrigo-brito/ninjabot/strategy"
 
-	"github.com/markcheno/go-talib"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -21,8 +21,8 @@ func (e Turtle) WarmupPeriod() int {
 }
 
 func (e Turtle) Indicators(df *ninjabot.Dataframe) []strategy.ChartIndicator {
-	df.Metadata["turtleHighest"] = talib.Max(df.Close, 40)
-	df.Metadata["turtleLowest"] = talib.Min(df.Close, 20)
+	df.Metadata["turtleHighest"] = indicator.Max(df.Close, 40)
+	df.Metadata["turtleLowest"] = indicator.Min(df.Close, 20)
 
 	return nil
 }

--- a/indicator/supertrend.go
+++ b/indicator/supertrend.go
@@ -1,0 +1,47 @@
+package indicator
+
+import "github.com/markcheno/go-talib"
+
+func SuperTrend(high, low, close []float64, atrPeriod int, factor float64) []float64 {
+	atr := talib.Atr(high, low, close, atrPeriod)
+	basicUpperBand := make([]float64, len(atr))
+	basicLowerBand := make([]float64, len(atr))
+	finalUpperBand := make([]float64, len(atr))
+	finalLowerBand := make([]float64, len(atr))
+	superTrend := make([]float64, len(atr))
+
+	for i := 1; i < len(basicLowerBand); i++ {
+		basicUpperBand[i] = (high[i]+low[i])/2.0 + atr[i]*factor
+		basicLowerBand[i] = (high[i]+low[i])/2.0 - atr[i]*factor
+
+		if basicUpperBand[i] < finalUpperBand[i-1] ||
+			close[i-1] > finalUpperBand[i-1] {
+			finalUpperBand[i] = basicUpperBand[i]
+		} else {
+			finalUpperBand[i] = finalUpperBand[i-1]
+		}
+
+		if basicLowerBand[i] > finalLowerBand[i-1] ||
+			close[i-1] < finalLowerBand[i-1] {
+			finalLowerBand[i] = basicLowerBand[i]
+		} else {
+			finalLowerBand[i] = finalLowerBand[i-1]
+		}
+
+		if finalUpperBand[i-1] == superTrend[i-1] {
+			if close[i] > finalUpperBand[i] {
+				superTrend[i] = finalLowerBand[i]
+			} else {
+				superTrend[i] = finalUpperBand[i]
+			}
+		} else {
+			if close[i] < finalLowerBand[i] {
+				superTrend[i] = finalUpperBand[i]
+			} else {
+				superTrend[i] = finalLowerBand[i]
+			}
+		}
+	}
+
+	return superTrend
+}

--- a/indicator/talib.go
+++ b/indicator/talib.go
@@ -1,0 +1,449 @@
+package indicator
+
+import "github.com/markcheno/go-talib"
+
+type MaType = talib.MaType
+
+// Kinds of moving averages
+const (
+	TypeSMA   = talib.SMA
+	TypeEMA   = talib.EMA
+	TypeWMA   = talib.WMA
+	TypeDEMA  = talib.DEMA
+	TypeTEMA  = talib.TEMA
+	TypeTRIMA = talib.TRIMA
+	TypeKAMA  = talib.KAMA
+	TypeMAMA  = talib.MAMA
+	TypeT3MA  = talib.T3MA
+)
+
+func BBands(input []float64, period int, deviation float64, maType MaType) ([]float64, []float64, []float64) {
+	return talib.BBands(input, period, deviation, deviation, maType)
+}
+
+// DEMA is a double exponential moving average
+func DEMA(input []float64, period int) []float64 {
+	return talib.Dema(input, period)
+}
+
+// EMA is a exponential moving average
+func EMA(input []float64, period int) []float64 {
+	return talib.Ema(input, period)
+}
+
+func HtTrendline(input []float64) []float64 {
+	return talib.HtTrendline(input)
+}
+
+func Kama(input []float64, period int) []float64 {
+	return talib.Kama(input, period)
+}
+
+// MA is a moving average
+func MA(input []float64, period int, maType MaType) []float64 {
+	return talib.Ma(input, period, maType)
+}
+
+func Mama(input []float64, inFastLimit float64, inSlowLimit float64) ([]float64, []float64) {
+	return talib.Mama(input, inFastLimit, inSlowLimit)
+}
+
+func MaVp(input []float64, inPeriods []float64, inMinPeriod int, inMaxPeriod int, maType MaType) []float64 {
+	return talib.MaVp(input, inPeriods, inMinPeriod, inMaxPeriod, maType)
+}
+
+func MidPoint(input []float64, period int) []float64 {
+	return talib.MidPoint(input, period)
+}
+
+func MidPrice(inHigh []float64, inLow []float64, period int) []float64 {
+	return talib.MidPrice(inHigh, inLow, period)
+}
+
+// SAR is a parabolic SAR
+func SAR(inHigh []float64, inLow []float64, inAcceleration float64, inMaximum float64) []float64 {
+	return talib.Sar(inHigh, inLow, inAcceleration, inMaximum)
+}
+
+func SarExt(inHigh []float64, inLow []float64,
+	inStartValue float64,
+	inOffsetOnReverse float64,
+	inAccelerationInitLong float64,
+	inAccelerationLong float64,
+	inAccelerationMaxLong float64,
+	inAccelerationInitShort float64,
+	inAccelerationShort float64,
+	inAccelerationMaxShort float64) []float64 {
+	return talib.SarExt(inHigh, inLow, inStartValue, inOffsetOnReverse, inAccelerationInitLong, inAccelerationLong, inAccelerationMaxLong, inAccelerationInitShort, inAccelerationShort, inAccelerationMaxShort)
+}
+
+// SMA is a simple moving average
+func SMA(input []float64, period int) []float64 {
+	return talib.Sma(input, period)
+}
+
+// T3 - Triple Exponential Moving Average (T3)
+func T3(input []float64, period int, inVFactor float64) []float64 {
+	return talib.T3(input, period, inVFactor)
+}
+
+// TEMA is a triple exponential moving average
+func TEMA(input []float64, period int) []float64 {
+	return talib.Tema(input, period)
+}
+
+func Trima(input []float64, period int) []float64 {
+	return talib.Trima(input, period)
+}
+
+// WMA is a weighted moving average
+func WMA(input []float64, period int) []float64 {
+	return talib.Wma(input, period)
+}
+
+// ADX is a relative strength index
+func ADX(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.Adx(inHigh, inLow, inClose, period)
+}
+
+func AdxR(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.AdxR(inHigh, inLow, inClose, period)
+}
+
+// APO - Absolute Price Oscillator
+func APO(input []float64, inFastPeriod int, inSlowPeriod int, maType MaType) []float64 {
+	return talib.Apo(input, inFastPeriod, inSlowPeriod, maType)
+}
+
+func Aroon(inHigh []float64, inLow []float64, period int) ([]float64, []float64) {
+	return talib.Aroon(inHigh, inLow, period)
+}
+
+func AroonOsc(inHigh []float64, inLow []float64, period int) []float64 {
+	return talib.AroonOsc(inHigh, inLow, period)
+}
+
+// BOP - Balance Of Power
+func BOP(inOpen []float64, inHigh []float64, inLow []float64, inClose []float64) []float64 {
+	return talib.Bop(inOpen, inHigh, inLow, inClose)
+}
+
+// CMO is a Chande Momentum Oscillator
+func CMO(input []float64, period int) []float64 {
+	return talib.Cmo(input, period)
+}
+
+// CCI is a commodity channel index
+func CCI(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.Cci(inHigh, inLow, inClose, period)
+}
+
+// DX - Directional Movement Index
+func DX(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.Dx(inHigh, inLow, inClose, period)
+}
+
+// MACD is a moving average convergence/divergence
+func MACD(input []float64, inFastPeriod int, inSlowPeriod int, inSignalPeriod int) ([]float64, []float64, []float64) {
+	return talib.Macd(input, inFastPeriod, inSlowPeriod, inSignalPeriod)
+}
+
+func MACDExt(input []float64, inFastPeriod int, inFastMAType MaType, inSlowPeriod int, inSlowMAType MaType, inSignalPeriod int, inSignalMAType MaType) ([]float64, []float64, []float64) {
+	return talib.MacdExt(input, inFastPeriod, inFastMAType, inSlowPeriod, inSlowMAType, inSignalPeriod, inSignalMAType)
+}
+
+func MACDFix(input []float64, inSignalPeriod int) ([]float64, []float64, []float64) {
+	return talib.MacdFix(input, inSignalPeriod)
+}
+
+func MinusDI(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.MinusDI(inHigh, inLow, inClose, period)
+}
+
+func MinusDM(inHigh []float64, inLow []float64, period int) []float64 {
+	return talib.MinusDM(inHigh, inLow, period)
+}
+
+// MFI is a money flow index
+func MFI(inHigh []float64, inLow []float64, inClose []float64, inVolume []float64, period int) []float64 {
+	return talib.Mfi(inHigh, inLow, inClose, inVolume, period)
+}
+
+func Momentum(input []float64, period int) []float64 {
+	return talib.Mom(input, period)
+}
+
+func PlusDI(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.PlusDI(inHigh, inLow, inClose, period)
+}
+
+func PlusDM(inHigh []float64, inLow []float64, period int) []float64 {
+	return talib.PlusDM(inHigh, inLow, period)
+}
+
+// PPO - Percentage Price Oscillator
+func PPO(input []float64, inFastPeriod int, inSlowPeriod int, maType MaType) []float64 {
+	return talib.Ppo(input, inFastPeriod, inSlowPeriod, maType)
+}
+
+// ROCP - Rate of change Percentage: (price-prevPrice)/prevPrice
+func ROCP(input []float64, period int) []float64 {
+	return talib.Rocp(input, period)
+}
+
+// ROC - Rate of change : ((price/prevPrice)-1)*100
+func ROC(input []float64, period int) []float64 {
+	return talib.Roc(input, period)
+}
+
+// ROCR - Rate of change ratio: (price/prevPrice)
+func ROCR(input []float64, period int) []float64 {
+	return talib.Rocr(input, period)
+}
+
+// ROCR100 - Rate of change ratio 100 scale: (price/prevPrice)*100
+func ROCR100(input []float64, period int) []float64 {
+	return talib.Rocr100(input, period)
+}
+
+// RSI is a relative strength index.
+func RSI(input []float64, period int) []float64 {
+	return talib.Rsi(input, period)
+}
+
+// Stoch is slow stochastic indicator.
+func Stoch(inHigh []float64, inLow []float64, inClose []float64, inFastKPeriod int, inSlowKPeriod int, inSlowKMAType MaType, inSlowDPeriod int, inSlowDMAType MaType) ([]float64, []float64) {
+	return talib.Stoch(inHigh, inLow, inClose, inFastKPeriod, inSlowKPeriod, inSlowKMAType, inSlowDPeriod, inSlowDMAType)
+}
+
+// StochF is fast stochastic indicator.
+func StochF(inHigh []float64, inLow []float64, inClose []float64, inFastKPeriod int, inFastDPeriod int, inFastDMAType MaType) ([]float64, []float64) {
+	return talib.StochF(inHigh, inLow, inClose, inFastKPeriod, inFastDPeriod, inFastDMAType)
+}
+
+// StochRSI is stochastic RSI indicator.
+func StochRSI(input []float64, period int, inFastKPeriod int, inFastDPeriod int, inFastDMAType MaType) ([]float64, []float64) {
+	return talib.StochRsi(input, period, inFastKPeriod, inFastDPeriod, inFastDMAType)
+}
+
+func Trix(input []float64, period int) []float64 {
+	return talib.Trix(input, period)
+}
+
+func UltOsc(inHigh []float64, inLow []float64, inClose []float64, period1 int, period2 int, period3 int) []float64 {
+	return talib.UltOsc(inHigh, inLow, inClose, period1, period2, period3)
+}
+
+// WilliamsR is a Williams %R indicator.
+func WilliamsR(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.WillR(inHigh, inLow, inClose, period)
+}
+
+func Ad(inHigh []float64, inLow []float64, inClose []float64, inVolume []float64) []float64 {
+	return talib.Ad(inHigh, inLow, inClose, inVolume)
+}
+
+func AdOsc(inHigh []float64, inLow []float64, inClose []float64, inVolume []float64, inFastPeriod int, inSlowPeriod int) []float64 {
+	return talib.AdOsc(inHigh, inLow, inClose, inVolume, inFastPeriod, inSlowPeriod)
+}
+
+// OBV is the On Balance Volume indicator.
+func OBV(input []float64, inVolume []float64) []float64 {
+	return talib.Obv(input, inVolume)
+}
+
+// ATR is the Average True Range indicator.
+func ATR(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.Atr(inHigh, inLow, inClose, period)
+}
+
+// NATR is the normalized Average True Range indicator.
+func Natr(inHigh []float64, inLow []float64, inClose []float64, period int) []float64 {
+	return talib.Natr(inHigh, inLow, inClose, period)
+}
+
+// TRANGE is the True Range indicator.
+func TRANGE(inHigh []float64, inLow []float64, inClose []float64) []float64 {
+	return talib.TRange(inHigh, inLow, inClose)
+}
+
+func AvgPrice(inOpen []float64, inHigh []float64, inLow []float64, inClose []float64) []float64 {
+	return talib.AvgPrice(inOpen, inHigh, inLow, inClose)
+}
+
+func MedPrice(inHigh []float64, inLow []float64) []float64 {
+	return talib.MedPrice(inHigh, inLow)
+}
+
+func TypPrice(inHigh []float64, inLow []float64, inClose []float64) []float64 {
+	return talib.TypPrice(inHigh, inLow, inClose)
+}
+
+func WCLPrice(inHigh []float64, inLow []float64, inClose []float64) []float64 {
+	return talib.WclPrice(inHigh, inLow, inClose)
+}
+
+func HTDcPeriod(input []float64) []float64 {
+	return talib.HtDcPeriod(input)
+}
+
+func HTDcPhase(input []float64) []float64 {
+	return talib.HtDcPhase(input)
+}
+
+func HTPhasor(input []float64) ([]float64, []float64) {
+	return talib.HtPhasor(input)
+}
+
+func HTSine(input []float64) ([]float64, []float64) {
+	return talib.HtSine(input)
+}
+
+func HTTrendMode(input []float64) []float64 {
+	return talib.HtTrendMode(input)
+}
+
+func Beta(input0 []float64, input1 []float64, period int) []float64 {
+	return talib.Beta(input0, input1, period)
+}
+
+func Correl(input0 []float64, input1 []float64, period int) []float64 {
+	return talib.Correl(input0, input1, period)
+}
+
+func LinearReg(input []float64, period int) []float64 {
+	return talib.LinearReg(input, period)
+}
+
+func LinearRegAngle(input []float64, period int) []float64 {
+	return talib.LinearRegAngle(input, period)
+}
+
+func LinearRegIntercept(input []float64, period int) []float64 {
+	return talib.LinearRegIntercept(input, period)
+}
+
+func LinearRegSlope(input []float64, period int) []float64 {
+	return talib.LinearRegSlope(input, period)
+}
+
+func StdDev(input []float64, period int, inNbDev float64) []float64 {
+	return talib.StdDev(input, period, inNbDev)
+}
+
+// TSF - Time Series Forecast
+func TSF(input []float64, period int) []float64 {
+	return talib.Tsf(input, period)
+}
+
+func Var(input []float64, period int) []float64 {
+	return talib.Var(input, period)
+}
+
+/* Math Transform Functions */
+
+func Acos(input []float64) []float64 {
+	return talib.Acos(input)
+}
+
+func Asin(input []float64) []float64 {
+	return talib.Asin(input)
+}
+
+func Atan(input []float64) []float64 {
+	return talib.Atan(input)
+}
+
+func Ceil(input []float64) []float64 {
+	return talib.Ceil(input)
+}
+
+func Cos(input []float64) []float64 {
+	return talib.Cos(input)
+}
+
+func Cosh(input []float64) []float64 {
+	return talib.Cosh(input)
+}
+
+func Exp(input []float64) []float64 {
+	return talib.Exp(input)
+}
+
+func Floor(input []float64) []float64 {
+	return talib.Floor(input)
+}
+
+func Ln(input []float64) []float64 {
+	return talib.Ln(input)
+}
+
+func Log10(input []float64) []float64 {
+	return talib.Log10(input)
+}
+
+func Sin(input []float64) []float64 {
+	return talib.Sin(input)
+}
+
+func Sinh(input []float64) []float64 {
+	return talib.Sinh(input)
+}
+
+func Sqrt(input []float64) []float64 {
+	return talib.Sqrt(input)
+}
+
+func Tan(input []float64) []float64 {
+	return talib.Tan(input)
+}
+
+func Tanh(input []float64) []float64 {
+	return talib.Tanh(input)
+}
+
+/* Math Operator Functions */
+
+func Add(input0 []float64, input1 []float64) []float64 {
+	return talib.Add(input0, input1)
+}
+
+func Div(input0 []float64, input1 []float64) []float64 {
+	return talib.Div(input0, input1)
+}
+
+func Max(input []float64, period int) []float64 {
+	return talib.Max(input, period)
+}
+
+func MaxIndex(input []float64, period int) []float64 {
+	return talib.MaxIndex(input, period)
+}
+
+func Min(input []float64, period int) []float64 {
+	return talib.Min(input, period)
+}
+
+func MinIndex(input []float64, period int) []float64 {
+	return talib.MinIndex(input, period)
+}
+
+func MinMax(input []float64, period int) ([]float64, []float64) {
+	return talib.MinMax(input, period)
+}
+
+func MinMaxIndex(input []float64, period int) ([]float64, []float64) {
+	return talib.MinMaxIndex(input, period)
+}
+
+func Mult(input0 []float64, input1 []float64) []float64 {
+	return talib.Mult(input0, input1)
+}
+
+func Sub(input0 []float64, input1 []float64) []float64 {
+	return talib.Sub(input0, input1)
+}
+
+func Sum(input []float64, period int) []float64 {
+	return talib.Sum(input, period)
+}


### PR DESCRIPTION
Include native module of indicators

Example of usage:

```go
import  "github.com/rodrigo-brito/ninjabot/indicator"

func (e MyStrategy) Indicators(df *ninjabot.Dataframe) []strategy.ChartIndicator {
	df.Metadata["ema"] = indicator.EMA(df.Close, 40)
	df.Metadata["sma"] = indicator.SMA(df.Close, 20)

	return nil
}
```