### PR TITLE
feat(download): include flag to futures market

### DIFF
--- a/cmd/ninjabot/ninjabot.go
+++ b/cmd/ninjabot/ninjabot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rodrigo-brito/ninjabot/download"
 	"github.com/rodrigo-brito/ninjabot/exchange"
+	"github.com/rodrigo-brito/ninjabot/service"
 
 	"github.com/urfave/cli/v2"
 )
@@ -59,11 +60,32 @@ func main() {
 						Usage:    "eg. ./btc.csv",
 						Required: true,
 					},
+					&cli.BoolFlag{
+						Name:     "futures",
+						Aliases:  []string{"f"},
+						Usage:    "true or false",
+						Value:    false,
+						Required: false,
+					},
 				},
 				Action: func(c *cli.Context) error {
-					exc, err := exchange.NewBinance(c.Context)
-					if err != nil {
-						return err
+					var (
+						exc service.Feeder
+						err error
+					)
+
+					if c.Bool("futures") {
+						// fetch data from binance futures
+						exc, err = exchange.NewBinanceFuture(c.Context)
+						if err != nil {
+							return err
+						}
+					} else {
+						// fetch data from binance spot
+						exc, err = exchange.NewBinance(c.Context)
+						if err != nil {
+							return err
+						}
 					}
 
 					var options []download.Option

--- a/download/download.go
+++ b/download/download.go
@@ -16,10 +16,10 @@ import (
 const batchSize = 500
 
 type Downloader struct {
-	exchange service.Exchange
+	exchange service.Feeder
 }
 
-func NewDownloader(exchange service.Exchange) Downloader {
+func NewDownloader(exchange service.Feeder) Downloader {
 	return Downloader{
 		exchange: exchange,
 	}

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -76,7 +76,6 @@ func TestDownloader_download(t *testing.T) {
 	require.NoError(t, err)
 
 	fakeExchange := struct {
-		service.Broker
 		service.Feeder
 	}{
 		Feeder: csvFeed,

--- a/exchange/binance_future.go
+++ b/exchange/binance_future.go
@@ -134,7 +134,7 @@ func NewBinanceFuture(ctx context.Context, options ...BinanceFutureOption) (*Bin
 		exchange.assetsInfo[info.Symbol] = tradeLimits
 	}
 
-	log.Info("[SETUP] Using Binance exchange")
+	log.Info("[SETUP] Using Binance Futures exchange")
 
 	return exchange, nil
 }


### PR DESCRIPTION
Includ flag to download from futures market `--futures`

`ninjabot download --futures -p BTCUSDT -d 10 -t 1h-o example.csv`

##### Related Issues
Closes: https://github.com/rodrigo-brito/ninjabot/issues/249
