### PR TITLE
fix(paperwallet): fix panic when asset is zero

### DIFF
--- a/exchange/paperwallet.go
+++ b/exchange/paperwallet.go
@@ -184,7 +184,12 @@ func (p *PaperWallet) Summary() {
 	fmt.Println("-- FINAL WALLET --")
 	for pair := range p.lastCandle {
 		asset, quote := SplitAssetQuote(pair)
-		quantity := p.assets[asset].Free + p.assets[asset].Lock
+		assetInfo, ok := p.assets[asset]
+		if !ok {
+			continue
+		}
+
+		quantity := assetInfo.Free + assetInfo.Lock
 		value := quantity * p.lastCandle[pair].Close
 		if quantity < 0 {
 			totalShort := 2.0*p.avgShortPrice[pair]*quantity - p.lastCandle[pair].Close*quantity


### PR DESCRIPTION
### What have you changed and why?
In backtesting, a panic occurs when the strategy has no trades.
