### PR TITLE
feat: support custom binance api endpoint

### DIFF
--- a/exchange/binance.go
+++ b/exchange/binance.go
@@ -56,7 +56,7 @@ func WithMetadataFetcher(fetcher MetadataFetchers) BinanceOption {
 
 // WithTestNet activate Bianance testnet
 func WithTestNet() BinanceOption {
-	return func(b *Binance) {
+	return func(_ *Binance) {
 		binance.UseTestnet = true
 	}
 }
@@ -67,7 +67,7 @@ func WithCustomMainAPIEndpoint(apiURL, wsURL, combinedURL string) BinanceOption 
 		log.Fatal("missing url parameters for custom endpoint configuration")
 	}
 
-	return func(b *Binance) {
+	return func(_ *Binance) {
 		binance.BaseAPIMainURL = apiURL
 		binance.BaseWsMainURL = wsURL
 		binance.BaseCombinedMainURL = combinedURL
@@ -80,7 +80,7 @@ func WithCustomTestnetAPIEndpoint(apiURL, wsURL, combinedURL string) BinanceOpti
 		log.Fatal("missing url parameters for custom endpoint configuration")
 	}
 
-	return func(b *Binance) {
+	return func(_ *Binance) {
 		binance.BaseAPITestnetURL = apiURL
 		binance.BaseWsTestnetURL = wsURL
 		binance.BaseCombinedTestnetURL = combinedURL

--- a/exchange/binance.go
+++ b/exchange/binance.go
@@ -61,6 +61,32 @@ func WithTestNet() BinanceOption {
 	}
 }
 
+// WithCustomMainAPIEndpoint will set custom endpoints for the Binance Main API
+func WithCustomMainAPIEndpoint(apiURL, wsURL, combinedURL string) BinanceOption {
+	if apiURL == "" || wsURL == "" || combinedURL == "" {
+		log.Fatal("missing url parameters for custom endpoint configuration")
+	}
+
+	return func(b *Binance) {
+		binance.BaseAPIMainURL = apiURL
+		binance.BaseWsMainURL = wsURL
+		binance.BaseCombinedMainURL = combinedURL
+	}
+}
+
+// WithCustomTestnetAPIEndpoint will set custom endpoints for the Binance Testnet API
+func WithCustomTestnetAPIEndpoint(apiURL, wsURL, combinedURL string) BinanceOption {
+	if apiURL == "" || wsURL == "" || combinedURL == "" {
+		log.Fatal("missing url parameters for custom endpoint configuration")
+	}
+
+	return func(b *Binance) {
+		binance.BaseAPITestnetURL = apiURL
+		binance.BaseWsTestnetURL = wsURL
+		binance.BaseCombinedTestnetURL = combinedURL
+	}
+}
+
 // NewBinance create a new Binance exchange instance
 func NewBinance(ctx context.Context, options ...BinanceOption) (*Binance, error) {
 	binance.WebsocketKeepalive = true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/StudioSol/set v1.0.0
-	github.com/adshao/go-binance/v2 v2.4.5
+	github.com/adshao/go-binance/v2 v2.5.0
 	github.com/aybabtme/uniplot v0.0.0-20151203143629-039c559e5e7e
 	github.com/evanw/esbuild v0.19.5
 	github.com/glebarez/sqlite v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/StudioSol/set v1.0.0 h1:G27J71la+Da08WidabBkoRrvPLTa4cdCn0RjvyJ5WKQ=
 github.com/StudioSol/set v1.0.0/go.mod h1:hIUNZPo6rEGF43RlPXHq7Fjmf+HkVJBqAjtK7Z9LoIU=
-github.com/adshao/go-binance/v2 v2.4.5 h1:V3KpolmS9a7TLVECSrl2gYm+GGBSxhVk9ILaxvOTOVw=
-github.com/adshao/go-binance/v2 v2.4.5/go.mod h1:41Up2dG4NfMXpCldrDPETEtiOq+pHoGsFZ73xGgaumo=
+github.com/adshao/go-binance/v2 v2.5.0 h1:mk8ylSjIzDYVBF9Wf2KXu6GWD/Ws4LLzD9q2R2mqZB0=
+github.com/adshao/go-binance/v2 v2.5.0/go.mod h1:41Up2dG4NfMXpCldrDPETEtiOq+pHoGsFZ73xGgaumo=
 github.com/aybabtme/uniplot v0.0.0-20151203143629-039c559e5e7e h1:dSeuFcs4WAJJnswS8vXy7YY1+fdlbVPuEVmDAfqvFOQ=
 github.com/aybabtme/uniplot v0.0.0-20151203143629-039c559e5e7e/go.mod h1:uh71c5Vc3VNIplXOFXsnDy21T1BepgT32c5X/YPrOyc=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=

--- a/ninjabot.go
+++ b/ninjabot.go
@@ -125,7 +125,7 @@ func WithStorage(storage storage.Storage) Option {
 
 // WithLogLevel sets the log level. eg: log.DebugLevel, log.InfoLevel, log.WarnLevel, log.ErrorLevel, log.FatalLevel
 func WithLogLevel(level log.Level) Option {
-	return func(bot *NinjaBot) {
+	return func(_ *NinjaBot) {
 		log.SetLevel(level)
 	}
 }

--- a/order/feed_test.go
+++ b/order/feed_test.go
@@ -16,7 +16,7 @@ func TestFeed_Subscribe(t *testing.T) {
 	feed, pair := NewOrderFeed(), "blaus"
 	called := make(chan bool, 1)
 
-	feed.Subscribe(pair, func(order model.Order) {
+	feed.Subscribe(pair, func(_ model.Order) {
 		called <- true
 	}, false)
 

--- a/plot/chart.go
+++ b/plot/chart.go
@@ -423,7 +423,7 @@ func (c *Chart) Start() error {
 		http.FileServer(http.FS(staticFiles)),
 	)
 
-	http.HandleFunc("/assets/chart.js", func(w http.ResponseWriter, req *http.Request) {
+	http.HandleFunc("/assets/chart.js", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-type", "application/javascript")
 		fmt.Fprint(w, c.scriptContent)
 	})

--- a/storage/buntdb.go
+++ b/storage/buntdb.go
@@ -73,7 +73,7 @@ func (b Bunt) UpdateOrder(order *model.Order) error {
 func (b Bunt) Orders(filters ...OrderFilter) ([]*model.Order, error) {
 	orders := make([]*model.Order, 0)
 	err := b.db.View(func(tx *buntdb.Tx) error {
-		err := tx.Ascend("update_index", func(key, value string) bool {
+		err := tx.Ascend("update_index", func(_, value string) bool {
 			var order model.Order
 			err := json.Unmarshal([]byte(value), &order)
 			if err != nil {


### PR DESCRIPTION
Add new BinanceOption to configure custom API endpoint

### What have you changed and why?
I've added a new binanceOption that allows users to configure a custom API endpoint. This change was necessary to accommodate scenarios where using a non-global Binance instance or setting a custom endpoint could improve connection latency.

##### Related Issues
#305 
