### PR TITLE
add configurable root path to default database

### DIFF
--- a/ninjabot.go
+++ b/ninjabot.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"path/filepath"
 
 	"github.com/aybabtme/uniplot/histogram"
 

--- a/ninjabot.go
+++ b/ninjabot.go
@@ -24,13 +24,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
-var defaultDatabase = func() string {
-	rootPath := os.Getenv("NINJABOT_CONFIG_ROOT_PATH")
-	if rootPath == "" {
-		return "ninjabot.db"
-	}
-	return filepath.Join(rootPath, "ninjabot.db")
-}()
+const defaultDatabase = "ninjabot.db"
 
 func init() {
 	log.SetFormatter(&log.TextFormatter{
@@ -48,6 +42,7 @@ type CandleSubscriber interface {
 }
 
 type NinjaBot struct {
+	rootPath string
 	storage  storage.Storage
 	settings model.Settings
 	exchange service.Exchange
@@ -93,7 +88,7 @@ func NewBot(ctx context.Context, settings model.Settings, exch service.Exchange,
 
 	var err error
 	if bot.storage == nil {
-		bot.storage, err = storage.FromFile(defaultDatabase)
+		bot.storage, err = storage.FromFile(filepath.Join(bot.rootPath, defaultDatabase))
 		if err != nil {
 			return nil, err
 		}
@@ -111,6 +106,13 @@ func NewBot(ctx context.Context, settings model.Settings, exch service.Exchange,
 	}
 
 	return bot, nil
+}
+
+// WithRootPathForDefaultStoragePath sets a root path for the default storage path
+func WithRootPathForDefaultStoragePath(rootPath string) Option {
+	return func(bot *NinjaBot) {
+		bot.rootPath = rootPath
+	}
 }
 
 // WithBacktest sets the bot to run in backtest mode, it is required for backtesting environments

--- a/ninjabot.go
+++ b/ninjabot.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aybabtme/uniplot/histogram"
 
@@ -24,11 +24,11 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
-const defaultDatabase = func() string {
+var defaultDatabase = func() string {
 	rootPath := os.Getenv("NINJABOT_CONFIG_ROOT_PATH")
 	if rootPath == "" {
-	return "ninjabot.db"
-		}
+		return "ninjabot.db"
+	}
 	return filepath.Join(rootPath, "ninjabot.db")
 }()
 


### PR DESCRIPTION
<!-- A short description can be included here -->
if you run this bot with default database within k8s, you
might want to permanently store the database on a persistent volume

this enables devs to quickly ensure that the database is stored at a 
location that is persistent - allowing statefulness.

tiny feature aimed at letting developers with minimum investment setting up the bot 
so it works statefully within k8s with minimal effort <3

<!-- Please ensure that reviewers are assigned -->

### What have you changed and why?
Describe your changes here.
adds a functional option to the bot:
`
// WithRootPathForDefaultStoragePath sets a root path for the default storage path
func WithRootPathForDefaultStoragePath(rootPath string) Option {
	return func(bot *NinjaBot) {
		bot.rootPath = rootPath
	}
}`

which sets a default root path for the default sqlite db

so you can do something like:

`	bot, err := ninjabot.NewBot(ctx, settings, binance, strategy, ninjabot.WithRootPathForDefaultStoragePath(os.Getenv("ROOT_STORAGE_PATH")))
	if err != nil {
		log.Fatalln(err)
	}`

##### Related Issues
Link related issues here.
