### PR TITLE
chore: adjust exchange directory reference on read.me

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ Chart available at http://localhost:8080
 
 ### Exchanges
 
-Currently, we only support [Binance](https://www.binance.com/en?ref=35723227) exchange. If you want to include support for other exchanges, you need to implement a new `struct` that implements the interface `Exchange`. You can check some examples in [exchange](./pkg/exchange) directory.
+Currently, we only support [Binance](https://www.binance.com/en?ref=35723227) exchange. If you want to include support for other exchanges, you need to implement a new `struct` that implements the interface `Exchange`. You can check some examples in [exchange](exchange) directory.
 
 ### Support the project
 


### PR DESCRIPTION
Fix outdated exhange directory reference, point to exchange path instead of pkg/exchange
