### PR TITLE
fix: make Telegram /stop actually pause order placement

### DIFF
--- a/order/controller.go
+++ b/order/controller.go
@@ -2,6 +2,7 @@ package order
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -18,6 +19,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 )
+
+// ErrBotStopped is returned by CreateOrder* when the controller has been stopped.
+// Cancel is intentionally not gated, so open orders can still be cleaned up.
+var ErrBotStopped = errors.New("bot is stopped")
 
 type summary struct {
 	Pair             string
@@ -418,42 +423,58 @@ func (c *Controller) updateOrders() {
 }
 
 func (c *Controller) Status() Status {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 	return c.status
 }
 
+// requireRunning rejects new orders only after an explicit Stop().
+// Controllers that never called Start() keep the zero-value status and still
+// accept orders, preserving the public API for direct embedding / tests.
+// Must be called while holding c.mtx.
 func (c *Controller) requireRunning() error {
-	if c.status != StatusRunning {
-		return fmt.Errorf("bot is stopped")
+	if c.status == StatusStopped {
+		return ErrBotStopped
 	}
 	return nil
 }
 
 func (c *Controller) Start() {
-	if c.status != StatusRunning {
-		c.status = StatusRunning
-		go func() {
-			ticker := time.NewTicker(c.tickerInterval)
-			for {
-				select {
-				case <-ticker.C:
-					c.updateOrders()
-				case <-c.finish:
-					ticker.Stop()
-					return
-				}
-			}
-		}()
-		log.Info("Bot started.")
+	c.mtx.Lock()
+	if c.status == StatusRunning {
+		c.mtx.Unlock()
+		return
 	}
+	c.status = StatusRunning
+	c.mtx.Unlock()
+
+	go func() {
+		ticker := time.NewTicker(c.tickerInterval)
+		for {
+			select {
+			case <-ticker.C:
+				c.updateOrders()
+			case <-c.finish:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+	log.Info("Bot started.")
 }
 
 func (c *Controller) Stop() {
-	if c.status == StatusRunning {
-		c.status = StatusStopped
-		c.updateOrders()
-		c.finish <- true
-		log.Info("Bot stopped.")
+	c.mtx.Lock()
+	if c.status != StatusRunning {
+		c.mtx.Unlock()
+		return
 	}
+	c.status = StatusStopped
+	c.mtx.Unlock()
+
+	c.updateOrders()
+	c.finish <- true
+	log.Info("Bot stopped.")
 }
 
 func (c *Controller) Account() (model.Account, error) {

--- a/order/controller.go
+++ b/order/controller.go
@@ -421,6 +421,13 @@ func (c *Controller) Status() Status {
 	return c.status
 }
 
+func (c *Controller) requireRunning() error {
+	if c.status != StatusRunning {
+		return fmt.Errorf("bot is stopped")
+	}
+	return nil
+}
+
 func (c *Controller) Start() {
 	if c.status != StatusRunning {
 		c.status = StatusRunning
@@ -481,6 +488,10 @@ func (c *Controller) CreateOrderOCO(side model.SideType, pair string, size, pric
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	if err := c.requireRunning(); err != nil {
+		return nil, err
+	}
+
 	log.Infof("[ORDER] Creating OCO order for %s", pair)
 	orders, err := c.exchange.CreateOrderOCO(side, pair, size, price, stop, stopLimit)
 	if err != nil {
@@ -504,6 +515,10 @@ func (c *Controller) CreateOrderLimit(side model.SideType, pair string, size, li
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	if err := c.requireRunning(); err != nil {
+		return model.Order{}, err
+	}
+
 	log.Infof("[ORDER] Creating LIMIT %s order for %s", side, pair)
 	order, err := c.exchange.CreateOrderLimit(side, pair, size, limit)
 	if err != nil {
@@ -524,6 +539,10 @@ func (c *Controller) CreateOrderLimit(side model.SideType, pair string, size, li
 func (c *Controller) CreateOrderMarketQuote(side model.SideType, pair string, amount float64) (model.Order, error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+
+	if err := c.requireRunning(); err != nil {
+		return model.Order{}, err
+	}
 
 	log.Infof("[ORDER] Creating MARKET %s order for %s", side, pair)
 	order, err := c.exchange.CreateOrderMarketQuote(side, pair, amount)
@@ -549,6 +568,10 @@ func (c *Controller) CreateOrderMarket(side model.SideType, pair string, size fl
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	if err := c.requireRunning(); err != nil {
+		return model.Order{}, err
+	}
+
 	log.Infof("[ORDER] Creating MARKET %s order for %s", side, pair)
 	order, err := c.exchange.CreateOrderMarket(side, pair, size)
 	if err != nil {
@@ -572,6 +595,10 @@ func (c *Controller) CreateOrderMarket(side model.SideType, pair string, size fl
 func (c *Controller) CreateOrderStop(pair string, size float64, limit float64) (model.Order, error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+
+	if err := c.requireRunning(); err != nil {
+		return model.Order{}, err
+	}
 
 	log.Infof("[ORDER] Creating STOP order for %s", pair)
 	order, err := c.exchange.CreateOrderStop(pair, size, limit)

--- a/order/controller_test.go
+++ b/order/controller_test.go
@@ -222,3 +222,44 @@ func TestController_Position(t *testing.T) {
 	assert.Equal(t, 1.0, asset)
 	assert.Equal(t, 1500.0, quote)
 }
+
+func TestController_StopGatesCreateOrder(t *testing.T) {
+	storage, err := storage.FromMemory()
+	require.NoError(t, err)
+	ctx := context.Background()
+	wallet := exchange.NewPaperWallet(ctx, "USDT",
+		exchange.WithPaperAsset("USDT", 3000),
+		exchange.WithPaperAsset("BTC", 1),
+	)
+	controller := NewController(ctx, wallet, storage, NewOrderFeed())
+	wallet.OnCandle(model.Candle{Pair: "BTCUSDT", Close: 1000})
+
+	// Zero-value status (never Start()'d) must still accept orders — public API.
+	_, err = controller.CreateOrderMarket(model.SideTypeBuy, "BTCUSDT", 0.1)
+	require.NoError(t, err)
+
+	controller.Start()
+	_, err = controller.CreateOrderLimit(model.SideTypeBuy, "BTCUSDT", 0.1, 900)
+	require.NoError(t, err)
+
+	controller.Stop()
+	_, err = controller.CreateOrderMarket(model.SideTypeBuy, "BTCUSDT", 0.1)
+	require.ErrorIs(t, err, ErrBotStopped)
+
+	_, err = controller.CreateOrderLimit(model.SideTypeSell, "BTCUSDT", 0.1, 1100)
+	require.ErrorIs(t, err, ErrBotStopped)
+
+	_, err = controller.CreateOrderStop("BTCUSDT", 0.1, 800)
+	require.ErrorIs(t, err, ErrBotStopped)
+
+	// Cancel stays available while stopped so open orders can be cleaned up.
+	err = controller.Cancel(model.Order{Pair: "BTCUSDT", ExchangeID: 1})
+	// Paper wallet may not know that id; we only care that Cancel is not gated.
+	require.NotErrorIs(t, err, ErrBotStopped)
+
+	controller.Start()
+	_, err = controller.CreateOrderMarket(model.SideTypeBuy, "BTCUSDT", 0.1)
+	require.NoError(t, err)
+
+	controller.Stop()
+}


### PR DESCRIPTION
## Summary

Closes #122.

`/stop` already flipped the controller to `StatusStopped`, but `CreateOrder*` never checked that flag, so strategies (and Telegram buy/sell) kept submitting orders.

## Changes

- Gate every `CreateOrder*` path on explicit `StatusStopped` (not "not running"), so Controllers that never called `Start()` keep working — including the existing unit tests and anyone embedding `order.Controller` directly
- Protect `status` reads/writes with `c.mtx` in `Start` / `Stop` / `Status`
- Export `ErrBotStopped` so callers can use `errors.Is`
- Unit test: order while stopped → `ErrBotStopped`; after `Start()` again → succeeds; `Cancel` still works while stopped

## Behavior note

While stopped, protective orders (`CreateOrderStop`, exit OCO) are blocked too. Intentional for #122 ("stopped means stopped"). `Cancel` is unchanged so open orders can still be cleaned up.

## Test plan

- [x] `go test ./order/...` covers stop gate + resume
- [ ] Start the bot with Telegram enabled
- [ ] Confirm orders still place while status is running
- [ ] Send `/stop`, confirm subsequent strategy/Telegram orders are rejected with `bot is stopped`
- [ ] Send `/start`, confirm order placement resumes
- [ ] While stopped, confirm `Cancel` still works